### PR TITLE
fix(rocm): build for RDNA4 (gfx1201) and repair the conformance test

### DIFF
--- a/crates/tritium-rocm/build.rs
+++ b/crates/tritium-rocm/build.rs
@@ -28,7 +28,7 @@ use std::process::Command;
 /// `gfx942`), and RDNA2/3 consumer (`gfx1030`, `gfx1100`). Extend as new AMD
 /// hardware is validated on the ROCm CI lane.
 const SUPPORTED_GFX_ARCHS: &[&str] =
-    &["gfx900", "gfx908", "gfx90a", "gfx942", "gfx1030", "gfx1100"];
+    &["gfx900", "gfx908", "gfx90a", "gfx942", "gfx1030", "gfx1100", "gfx1201"];
 
 fn main() {
     // Rebuild triggers regardless of feature state: cheap, and correct when the

--- a/crates/tritium-rocm/src/rocm.rs
+++ b/crates/tritium-rocm/src/rocm.rs
@@ -525,7 +525,7 @@ mod tests {
         };
         let vectors: Vec<_> = frozen_vectors()
             .into_iter()
-            .filter(|v| v.format == "tq2_0")
+            .filter(|v| v.format == tritium_core::TernaryFormat::Tq2_0)
             .collect();
         assert!(!vectors.is_empty(), "expected some tq2_0 frozen vectors");
 


### PR DESCRIPTION
Fixes the two defects that stop the ROCm backend from running on RDNA4.
Full physical-device report, including the wgpu/Vulkan results on the same box: #1

## User-visible outcome

Before this change, on a machine with ROCm installed and an RDNA4 GPU:

- `cargo test -p tritium-rocm --features rocm` **does not compile**;
- once it does compile, the conformance test **self-skips and the suite reports
  `test result: ok`** while executing zero vectors.

After it, the frozen-vector TQ2_0 subset actually runs on the device.

## The two changes

**1. `build.rs` — add `gfx1201` to `SUPPORTED_GFX_ARCHS`.**

The list ends at `gfx1100` (RDNA3). Without gfx1201 in `--offload-arch`, hipcc bundles
no code for the GPU and the module load fails:

```
skipping rocm conformance: no device (backend error: hipModuleLoadData: device kernel image is invalid (hip 200))
test rocm::tests::conformance_or_skip ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Two things are worth separating here. The diagnostic says **"no device"**, but the device is
present and healthy — the real cause is an arch-mismatched code object, which sends anyone
debugging this down the wrong path. And because `conformance_or_skip` converts the backend
error into a skip, the suite goes green having validated nothing, which is the opposite of
what CONTRIBUTING.md means by "a skipped test is not a pass". I have not changed that
behaviour in this PR — it is a design call for you — but it is why the missing arch went
unnoticed.

With gfx1201 added, the code object grows 52,152 → 60,344 bytes and bundles:

```
gfx900 gfx908 gfx942 gfx1030 gfx1100 gfx1201
```

and the test stops skipping.

The comment above the constant says "Extend as new AMD hardware is validated on the ROCm CI
lane", so this follows the documented intent. **`gfx1200` (RX 9060), `gfx1101`/`gfx1102`
(RX 7800/7700/7600) are also absent** — I left them out because I cannot validate them on
hardware I do not have, and this list is presented as a validated-hardware list.

**2. `rocm.rs` — compare against `TernaryFormat::Tq2_0`, not `"tq2_0"`.**

`0b27ba4` changed `ConformanceVector::format` from a string to `tritium_core::TernaryFormat`;
the ROCm lane was not updated:

```
error[E0308]: mismatched types
   --> crates/tritium-rocm/src/rocm.rs:528:37
    |            .filter(|v| v.format == "tq2_0")
    |                        expected `TernaryFormat`, found `&str`
```

It is inside `#[cfg(test)]`, so only a build with `--features rocm` *and* an AMD device
surfaces it.

## Tests and exact commands run

On the target device:

```sh
cargo build --locked -p tritium-rocm --features rocm     # PASS
cargo test  --locked -p tritium-rocm --features rocm     # PASS, no self-skip
```

Also run on the same checkout, for context rather than as a claim about this PR:

```sh
cargo build --locked                                              # PASS (22.6 s)
cargo test  --locked --workspace --exclude tritium-py --no-fail-fast
                                                                  # PASS 1347 / 0 failed / 22 ignored
cargo fmt --check                                                 # PASS
```

**Gates not run** (a skipped test is not a pass): `pytest` for `tritium-py`,
`npm --prefix packages/tritium-web run check`, `./scripts/check-semver.sh`,
`git diff --check`, and every CUDA / Metal / WASM / browser lane — no such hardware or
runtime on this box.

`cargo clippy --workspace --all-targets -- -D warnings` **fails on this checkout**, but for
an unrelated reason (unused imports in `crates/tritium-nn/tests/salt_distill_heldout.rs`,
introduced by `b83827b`). It is not touched by this PR; reported in #1 and I am happy to
send it as a separate one-line PR if you want it.

## Device, source and artifact identity

- Base: `b83827b3843534f399333a8f5dcca447e510e506` (v1.1.0-rc.0)
- GPU: AMD Radeon RX 9070 XT, **gfx1201 (RDNA4)**, 16304 MiB VRAM
- ROCm 7.2.4, hipcc HIP 7.2.53211-97f5574fe2, kernel 6.14.0-37, Ubuntu 24.04.4
- rustc 1.95.0 stable, no toolchain override
- Conformance vectors: `v070` (89 vectors), tolerance `Tolerance::default()` = relative 1e-4.
  **Not bit-exact** — I am reporting parity at the tolerance the harness applies, and did not
  verify a bit-exactness claim on this device.
- No model weights involved.

## Compatibility, security, memory, performance

- No public API, schema or artifact-format change. Test-only change plus one entry in a
  build-time arch list.
- The extra `--offload-arch` target grows the embedded code object by ~8 KB; no runtime
  memory or performance effect on existing architectures, which keep their own bundled code.
- `docs/compatibility.md` is generated and states ROCm is `unsupported`; I have not touched
  it, since flipping a row needs a digest-bound receipt produced by your own scripts.

## Known limitations and follow-up

- This makes the ROCm lane *execute* on RDNA4. It does not qualify RDNA4 — that is yours to
  decide, and would need the receipt machinery.
- The skip-reported-as-pass behaviour in `conformance_or_skip` is untouched.
- Separately: there is currently no way to run a model or a benchmark on the wgpu or ROCm
  backends at all — `tritium-cli` and `benches` depend only on `tritium-cuda`, so
  `tritium report compare --backend wgpu` cannot resolve. Details in #1. If you wire those
  crates in behind features mirroring `cuda`, I can run the full ledger command on this box
  and send you the JSON.

I have the hardware available and am happy to run further AMD lanes on request.
