### PR TITLE
fix(nn): gate the cuda-only distill imports so the CPU clippy gate passes

### DIFF
--- a/crates/tritium-nn/tests/salt_distill_heldout.rs
+++ b/crates/tritium-nn/tests/salt_distill_heldout.rs
@@ -15,7 +15,11 @@ mod common;
 
 use std::path::PathBuf;
 
-use common::{Calib, calibrate, extract, fold, forward, logits_of, perplexity_windowed};
+use common::{extract, forward, logits_of, perplexity_windowed};
+// `Calib`, `calibrate` and `fold` are used only by the cuda-gated
+// `salt_distillation_device_trainer_recovers_heldout` test below.
+#[cfg(feature = "cuda")]
+use common::{Calib, calibrate, fold};
 use tritium_nn::ModelRunner;
 use tritium_train::ops::ste;
 use tritium_train::{AdamW, Optimizer, Tape};


### PR DESCRIPTION
`cargo clippy --workspace --all-targets -- -D warnings` — the CPU gate published in
CONTRIBUTING.md — fails on a clean checkout of `b83827b`:

```
error: unused imports: `Calib`, `calibrate`, and `fold`
  --> crates/tritium-nn/tests/salt_distill_heldout.rs:18:14
   |
18 | use common::{Calib, calibrate, extract, fold, forward, logits_of, perplexity_windowed};
   |              ^^^^^  ^^^^^^^^^           ^^^^
   = note: `-D unused-imports` implied by `-D warnings`
```

## Why not just delete them

They are not dead code. All three are used inside
`salt_distillation_device_trainer_recovers_heldout`:

- `Calib::new` — line 405
- `calibrate(` — line 407
- `fold(&fp, &shapes, &a, &calib, alpha)` — line 414

and that test carries `#[cfg(feature = "cuda")]` (line 326). They are unused *only* when
the `cuda` feature is off — which is precisely the configuration the documented gate runs in.
Taking clippy's suggestion literally would fix the gate and break the cuda build.

So this gates the import to match its use. The other four — `extract`, `forward`,
`logits_of`, `perplexity_windowed` — are used unconditionally (lines 96/162/146/111 among
others) and are left alone.

## Tests and exact commands run

```sh
cargo clippy --locked --workspace --all-targets -- -D warnings   # PASS (was: error)
cargo fmt --check                                                # PASS
```

**What I could not verify:** the `cuda` side. This box has no NVIDIA GPU and no CUDA
toolkit, so `--features cuda` cannot be built here — `tritium-nn/cuda` pulls in
`tritium-cuda`, which needs nvcc. The change is textual and the three symbols keep exactly
the same visibility inside the cuda-gated test, but please run the cuda lane before merging.

**Gates not run:** `pytest` for `tritium-py`, `npm --prefix packages/tritium-web run check`,
`./scripts/check-semver.sh`, `git diff --check`, and all CUDA / Metal / WASM / browser lanes.

## Identity

- Base: `b83827b3843534f399333a8f5dcca447e510e506` (v1.1.0-rc.0)
- rustc 1.95.0 stable, Ubuntu 24.04.4, x86_64 (Ryzen 9 3900X, AVX2, no AVX-512)

## Scope

Test-file only, no public API or schema change. Independent of #2 (the ROCm/RDNA4 fixes) —
these can merge in either order. Found while running the CPU gate for the RDNA4 device
report in #1.
