### PR TITLE
ci: harden repository contribution and workflow controls

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - gpu
+    - rocm
+    - cuda
+    - sm89

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026
-        with:
-          tool: actionlint@1.7.7
+      - name: install pinned actionlint binary
+        env:
+          ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/actionlint_1.7.7_linux_amd64.tar.gz"
+          curl --fail --location --silent --show-error --retry 3 \
+            --output "$archive" \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz
+          echo "$ACTIONLINT_SHA256  $archive" | sha256sum --check --strict
+          tar --extract --gzip --file "$archive" --directory "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - run: actionlint
 
   # API-stability gate (ADR 0011/0012): no UNINTENTIONAL breaking change to the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,16 @@ jobs:
         with:
           command: check licenses bans sources advisories
 
+  workflow-lint:
+    name: workflow lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026
+        with:
+          tool: actionlint@1.7.7
+      - run: actionlint
+
   # API-stability gate (ADR 0011/0012): no UNINTENTIONAL breaking change to the
   # stable public-API crates vs the last v0.5.* release tag. Pre-1.0 breaks are
   # allowed but must be deliberate; this surfaces them. fetch-depth: 0 so the
@@ -492,6 +502,7 @@ jobs:
       - compatibility-matrix
       - web-package
       - cargo-deny
+      - workflow-lint
       - semver
       - cpu-bench-smoke
       - wasm

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -333,14 +333,12 @@ jobs:
           set -euo pipefail
           test ! -e "$GITHUB_WORKSPACE/.git"
           test ! -e "$GITHUB_WORKSPACE/Cargo.toml"
-          ! command -v cargo
-          ! command -v rustc
-          ! command -v cc
-          ! command -v c++
-          ! command -v gcc
-          ! command -v g++
-          ! command -v clang
-          ! command -v clang++
+          for compiler in cargo rustc cc c++ gcc g++ clang clang++; do
+            if command -v "$compiler" >/dev/null 2>&1; then
+              echo "compiler must be absent in source-free lane: $compiler" >&2
+              exit 1
+            fi
+          done
       - name: install pinned binary runtime and exact wheel
         shell: bash
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -85,6 +85,8 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          toolchain: 1.89.0
       - name: test wheel verifier
         run: python -m unittest scripts.tests.test_verify_wheel -v
       - name: test pinned CPU manylinux builder contract

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,8 +78,10 @@ jobs:
         platform:
           # Linux (manylinux, built in the maturin container).
           - { os: linux, runner: ubuntu-latest, target: x86_64, target_id: linux-x86_64-cpu, smoke: true }
-          # macOS (universal2 covers both Apple Silicon + Intel in one wheel).
-          - { os: macos, runner: macos-latest, target: universal2, target_id: macos-arm64-cpu, smoke: true }
+          # macOS arm64. The ONNX Runtime dependency has no prebuilt
+          # x86_64-apple-darwin binary, so universal2 would claim a slice that
+          # cannot be built. The qualified compatibility cell is arm64.
+          - { os: macos, runner: macos-latest, target: aarch64, target_id: macos-arm64-cpu, smoke: true }
           # Windows.
           - { os: windows, runner: windows-latest, target: x64, target_id: windows-x86_64-cpu, smoke: true }
     steps:
@@ -191,7 +193,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: wheel-macos-universal2
+          name: wheel-macos-aarch64
           path: dist
       - name: install exact abi3 wheel and run native smoke
         shell: bash

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `8dc6e575d056c029bc9dbabb470c90be1e9e2e63274094661bb6e3deeaa58bbc`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
+| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `843eb56dfa29dc89fe7fc0471ad79db65dac2af0980c20a9dca36214aba98da2`; revision `445d7e2a0f508ad32095b16ace9d75f10a161ed3` |
 | macOS arm64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 | Windows x86_64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 
@@ -30,7 +30,7 @@ with the listed stable diagnostic instead of silently falling back.
 | Target | Status | Evidence / failure |
 |---|---|---|
 | Linux CUDA wheels | **pending** | Driver, runtime, PyTorch and GPU-architecture receipts are not yet archived. |
-| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `fd35af0b89bcd021bddfa3ca5ef4010d6ed48253084383d55d88f7f813660ef7`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
+| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `56011088d810e5728113df26c5ac03e42715b098416b191060c356eb09db2cb2`; revision `445d7e2a0f508ad32095b16ace9d75f10a161ed3` |
 | Non-NVIDIA GPU execution backend (wgpu/Vulkan, ROCm) | **pending** | The tritium-cli and tritium-benches wgpu/rocm lanes now exist (issue #4), but no `tritium report compare` ledger JSON from a physical non-NVIDIA GPU has been archived. Compile-only and Vulkan-on-NVIDIA runs do not qualify this row. |
 | ROCm wheel | **unsupported** | `TRITIUM_UNSUPPORTED_ROCM_WHEEL_V1_1` |
 | Metal-specific wheel | **unsupported** | `TRITIUM_UNSUPPORTED_METAL_WHEEL_V1_1` |
@@ -46,7 +46,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `bedeb28fc16a4e0a727fd7d89d37375724c29762b547d4f2d2035845b741dfb7`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
+| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `a7750102955973a95ffc2e0c158f9cbec25108746a7793129862d6891befd849`; revision `445d7e2a0f508ad32095b16ace9d75f10a161ed3` |
 | Chrome WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Firefox WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Safari WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `24817404edde201a182b764072bc9573dcbb3483c8b1cc429791c1b668e68e83`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
+| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `8dc6e575d056c029bc9dbabb470c90be1e9e2e63274094661bb6e3deeaa58bbc`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
 | macOS arm64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 | Windows x86_64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 
@@ -30,7 +30,7 @@ with the listed stable diagnostic instead of silently falling back.
 | Target | Status | Evidence / failure |
 |---|---|---|
 | Linux CUDA wheels | **pending** | Driver, runtime, PyTorch and GPU-architecture receipts are not yet archived. |
-| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `cd7a15de62f6021ee41e9a46629d902f5fc2938cb4e273e11714c7fe26aa2e6b`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
+| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `fd35af0b89bcd021bddfa3ca5ef4010d6ed48253084383d55d88f7f813660ef7`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
 | Non-NVIDIA GPU execution backend (wgpu/Vulkan, ROCm) | **pending** | The tritium-cli and tritium-benches wgpu/rocm lanes now exist (issue #4), but no `tritium report compare` ledger JSON from a physical non-NVIDIA GPU has been archived. Compile-only and Vulkan-on-NVIDIA runs do not qualify this row. |
 | ROCm wheel | **unsupported** | `TRITIUM_UNSUPPORTED_ROCM_WHEEL_V1_1` |
 | Metal-specific wheel | **unsupported** | `TRITIUM_UNSUPPORTED_METAL_WHEEL_V1_1` |
@@ -46,7 +46,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `3674b2ad0b2b375bace1f244039f1ab4d9cdc97a61d9a1452816235f6b982551`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
+| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `bedeb28fc16a4e0a727fd7d89d37375724c29762b547d4f2d2035845b741dfb7`; revision `3662cc3f5125942a154a98bc9a694f6e7cbd4582` |
 | Chrome WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Firefox WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Safari WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,7 +14,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `61bd3a4e5ce0a61d14f8d9b2be753e0fbfcb3e89dbb58dd7c319bd989ec8fe7f`; revision `29503cef202f83cb042930379209b7ebae005d35` |
+| Linux x86_64 CPU wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cpu.json`](../release/compatibility-v1.1/linux-x86_64-cpu.json) SHA-256 `24817404edde201a182b764072bc9573dcbb3483c8b1cc429791c1b668e68e83`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
 | macOS arm64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 | Windows x86_64 CPU wheel | **pending** | Fresh no-compiler wheel receipt is not yet archived. |
 
@@ -30,7 +30,7 @@ with the listed stable diagnostic instead of silently falling back.
 | Target | Status | Evidence / failure |
 |---|---|---|
 | Linux CUDA wheels | **pending** | Driver, runtime, PyTorch and GPU-architecture receipts are not yet archived. |
-| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `fa29f38e50dcea72acf67c2b7fe35411fc21705087b320f3975f7797a8b6cc0b`; revision `29503cef202f83cb042930379209b7ebae005d35` |
+| Linux CUDA 13 sm_89 wheel | **qualified** | [`compatibility-v1.1/linux-x86_64-cuda13-sm89.json`](../release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json) SHA-256 `cd7a15de62f6021ee41e9a46629d902f5fc2938cb4e273e11714c7fe26aa2e6b`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
 | Non-NVIDIA GPU execution backend (wgpu/Vulkan, ROCm) | **pending** | The tritium-cli and tritium-benches wgpu/rocm lanes now exist (issue #4), but no `tritium report compare` ledger JSON from a physical non-NVIDIA GPU has been archived. Compile-only and Vulkan-on-NVIDIA runs do not qualify this row. |
 | ROCm wheel | **unsupported** | `TRITIUM_UNSUPPORTED_ROCM_WHEEL_V1_1` |
 | Metal-specific wheel | **unsupported** | `TRITIUM_UNSUPPORTED_METAL_WHEEL_V1_1` |
@@ -46,7 +46,7 @@ with the listed stable diagnostic instead of silently falling back.
 
 | Target | Status | Evidence / failure |
 |---|---|---|
-| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `9a140baa9ae6c3d1c2fa183f4f7057062e01883828f094ccb542868b780a9b7c`; revision `29503cef202f83cb042930379209b7ebae005d35` |
+| Node.js 22+ strict-TypeScript archive | **qualified** | [`compatibility-v1.1/node-22.json`](../release/compatibility-v1.1/node-22.json) SHA-256 `3674b2ad0b2b375bace1f244039f1ab4d9cdc97a61d9a1452816235f6b982551`; revision `62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830` |
 | Chrome WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Firefox WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |
 | Safari WebGPU training | **pending** | Actual-browser WebGPU receipt is not yet archived. |

--- a/release/compatibility-v1.1.json
+++ b/release/compatibility-v1.1.json
@@ -9,8 +9,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cpu.json",
-          "sha256": "24817404edde201a182b764072bc9573dcbb3483c8b1cc429791c1b668e68e83",
-          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
+          "sha256": "8dc6e575d056c029bc9dbabb470c90be1e9e2e63274094661bb6e3deeaa58bbc",
+          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
         }
       },
       {
@@ -53,8 +53,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cuda13-sm89.json",
-          "sha256": "cd7a15de62f6021ee41e9a46629d902f5fc2938cb4e273e11714c7fe26aa2e6b",
-          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
+          "sha256": "fd35af0b89bcd021bddfa3ca5ef4010d6ed48253084383d55d88f7f813660ef7",
+          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
         }
       },
       {
@@ -97,8 +97,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/node-22.json",
-          "sha256": "3674b2ad0b2b375bace1f244039f1ab4d9cdc97a61d9a1452816235f6b982551",
-          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
+          "sha256": "bedeb28fc16a4e0a727fd7d89d37375724c29762b547d4f2d2035845b741dfb7",
+          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
         }
       },
       {

--- a/release/compatibility-v1.1.json
+++ b/release/compatibility-v1.1.json
@@ -9,8 +9,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cpu.json",
-          "sha256": "61bd3a4e5ce0a61d14f8d9b2be753e0fbfcb3e89dbb58dd7c319bd989ec8fe7f",
-          "source_revision": "29503cef202f83cb042930379209b7ebae005d35"
+          "sha256": "24817404edde201a182b764072bc9573dcbb3483c8b1cc429791c1b668e68e83",
+          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
         }
       },
       {
@@ -53,8 +53,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cuda13-sm89.json",
-          "sha256": "fa29f38e50dcea72acf67c2b7fe35411fc21705087b320f3975f7797a8b6cc0b",
-          "source_revision": "29503cef202f83cb042930379209b7ebae005d35"
+          "sha256": "cd7a15de62f6021ee41e9a46629d902f5fc2938cb4e273e11714c7fe26aa2e6b",
+          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
         }
       },
       {
@@ -97,8 +97,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/node-22.json",
-          "sha256": "9a140baa9ae6c3d1c2fa183f4f7057062e01883828f094ccb542868b780a9b7c",
-          "source_revision": "29503cef202f83cb042930379209b7ebae005d35"
+          "sha256": "3674b2ad0b2b375bace1f244039f1ab4d9cdc97a61d9a1452816235f6b982551",
+          "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830"
         }
       },
       {

--- a/release/compatibility-v1.1.json
+++ b/release/compatibility-v1.1.json
@@ -9,8 +9,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cpu.json",
-          "sha256": "8dc6e575d056c029bc9dbabb470c90be1e9e2e63274094661bb6e3deeaa58bbc",
-          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
+          "sha256": "843eb56dfa29dc89fe7fc0471ad79db65dac2af0980c20a9dca36214aba98da2",
+          "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3"
         }
       },
       {
@@ -53,8 +53,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/linux-x86_64-cuda13-sm89.json",
-          "sha256": "fd35af0b89bcd021bddfa3ca5ef4010d6ed48253084383d55d88f7f813660ef7",
-          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
+          "sha256": "56011088d810e5728113df26c5ac03e42715b098416b191060c356eb09db2cb2",
+          "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3"
         }
       },
       {
@@ -97,8 +97,8 @@
         "status": "qualified",
         "receipt": {
           "path": "compatibility-v1.1/node-22.json",
-          "sha256": "bedeb28fc16a4e0a727fd7d89d37375724c29762b547d4f2d2035845b741dfb7",
-          "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582"
+          "sha256": "a7750102955973a95ffc2e0c158f9cbec25108746a7793129862d6891befd849",
+          "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3"
         }
       },
       {

--- a/release/compatibility-v1.1/linux-x86_64-cpu.json
+++ b/release/compatibility-v1.1/linux-x86_64-cpu.json
@@ -1,14 +1,14 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cpu",
-  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
+  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
   "host_arch": "x86_64",
   "wheel": "tritium_torch-1.1.0rc1-cp39-abi3-manylinux_2_28_x86_64.whl",
-  "sha256": "87424a99c8db7051df724d2106490859cbad6890b09c08b829b608f579d81d1b",
-  "bytes": 10806729,
+  "sha256": "40edda82a93bcb8036f052e279cbb20b3fcc110fef30000bcac70aa772494968",
+  "bytes": 10806798,
   "version": "1.1.0rc1",
   "platform_tag": "manylinux_2_28_x86_64"
 }

--- a/release/compatibility-v1.1/linux-x86_64-cpu.json
+++ b/release/compatibility-v1.1/linux-x86_64-cpu.json
@@ -1,7 +1,7 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cpu",
-  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
+  "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",

--- a/release/compatibility-v1.1/linux-x86_64-cpu.json
+++ b/release/compatibility-v1.1/linux-x86_64-cpu.json
@@ -1,14 +1,14 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cpu",
-  "source_revision": "29503cef202f83cb042930379209b7ebae005d35",
+  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
   "host_arch": "x86_64",
   "wheel": "tritium_torch-1.1.0rc1-cp39-abi3-manylinux_2_28_x86_64.whl",
-  "sha256": "617f88a23e08a2b1813a746de86e8552f0352bb59787876726e84068d9568e9e",
-  "bytes": 10806824,
+  "sha256": "87424a99c8db7051df724d2106490859cbad6890b09c08b829b608f579d81d1b",
+  "bytes": 10806729,
   "version": "1.1.0rc1",
   "platform_tag": "manylinux_2_28_x86_64"
 }

--- a/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
+++ b/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
@@ -1,7 +1,7 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cuda13-sm89",
-  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
+  "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",

--- a/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
+++ b/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
@@ -1,14 +1,14 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cuda13-sm89",
-  "source_revision": "29503cef202f83cb042930379209b7ebae005d35",
+  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
   "host_arch": "x86_64",
   "wheel": "tritium_torch-1.1.0rc1-cp39-abi3-manylinux_2_28_x86_64.whl",
-  "sha256": "617a9e3011dce2e90ef3bb2598032bebccae1b08556a8d7b6d12ff1217b7e39b",
-  "bytes": 2807068,
+  "sha256": "21df1b7475ff82bb23c5adfad8307fb9fe6ead461fed508ab66dc540d7b13db9",
+  "bytes": 2807163,
   "version": "1.1.0rc1",
   "platform_tag": "manylinux_2_28_x86_64"
 }

--- a/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
+++ b/release/compatibility-v1.1/linux-x86_64-cuda13-sm89.json
@@ -1,14 +1,14 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "linux-x86_64-cuda13-sm89",
-  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
+  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
   "host_arch": "x86_64",
   "wheel": "tritium_torch-1.1.0rc1-cp39-abi3-manylinux_2_28_x86_64.whl",
-  "sha256": "21df1b7475ff82bb23c5adfad8307fb9fe6ead461fed508ab66dc540d7b13db9",
-  "bytes": 2807163,
+  "sha256": "004e7ad9fd64a9939054da6295019b220f52f3cc3912d1e08444db463efcb59e",
+  "bytes": 2807085,
   "version": "1.1.0rc1",
   "platform_tag": "manylinux_2_28_x86_64"
 }

--- a/release/compatibility-v1.1/node-22.json
+++ b/release/compatibility-v1.1/node-22.json
@@ -1,7 +1,7 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "node-22",
-  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
+  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
@@ -12,12 +12,12 @@
   },
   "package": "@tritium-ai/web@1.1.0-rc.1",
   "archive": "tritium-ai-web-1.1.0-rc.1.tgz",
-  "archive_sha256": "fb415dc7685d3cd4ad141153dd8a2717d9be1c9493ab7102cf48187bfa7e98eb",
-  "archive_bytes": 638084,
+  "archive_sha256": "bd1c8866e03dd81dc842d3b5434bb94bddd71ad81da33e89abc270a63bb56e67",
+  "archive_bytes": 638122,
   "source_free": true,
   "installed_offline": true,
   "strict_typescript": true,
-  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
-  "wasm_guest_digest": "14c95330845568ae71af2a5013045341b0906071e47feed69105dfe1683c6272",
-  "upstream_receipt_id": "sha256:089092af10fe0d3bb614404a10ed1829c6ad52dee4a2a8747f2806b5cb3ebd1a"
+  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:3662cc3f5125942a154a98bc9a694f6e7cbd4582",
+  "wasm_guest_digest": "a6c85677e66a84620ea19bae415543640ba2afcf7bb395d5dce74830e8b92972",
+  "upstream_receipt_id": "sha256:05fddd546fbeba8a842f94346eb66f062cf7977214a9cef0ae590ccb69b20a66"
 }

--- a/release/compatibility-v1.1/node-22.json
+++ b/release/compatibility-v1.1/node-22.json
@@ -1,7 +1,7 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "node-22",
-  "source_revision": "3662cc3f5125942a154a98bc9a694f6e7cbd4582",
+  "source_revision": "445d7e2a0f508ad32095b16ace9d75f10a161ed3",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
@@ -12,12 +12,12 @@
   },
   "package": "@tritium-ai/web@1.1.0-rc.1",
   "archive": "tritium-ai-web-1.1.0-rc.1.tgz",
-  "archive_sha256": "bd1c8866e03dd81dc842d3b5434bb94bddd71ad81da33e89abc270a63bb56e67",
-  "archive_bytes": 638122,
+  "archive_sha256": "c95bd4cc23c9b4e0738896db73b61c11115a7dcf5cc0895d69a5b82141aae472",
+  "archive_bytes": 638121,
   "source_free": true,
   "installed_offline": true,
   "strict_typescript": true,
-  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:3662cc3f5125942a154a98bc9a694f6e7cbd4582",
-  "wasm_guest_digest": "a6c85677e66a84620ea19bae415543640ba2afcf7bb395d5dce74830e8b92972",
-  "upstream_receipt_id": "sha256:05fddd546fbeba8a842f94346eb66f062cf7977214a9cef0ae590ccb69b20a66"
+  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:445d7e2a0f508ad32095b16ace9d75f10a161ed3",
+  "wasm_guest_digest": "2d56ad57833abaa40a30be16b666b80f989df85e3d0f599a72e9ca30dc6578d2",
+  "upstream_receipt_id": "sha256:5ccd274831b1ef43d0c46357d7ee94875d72e3a47ba56f2505af45da6f72b5ed"
 }

--- a/release/compatibility-v1.1/node-22.json
+++ b/release/compatibility-v1.1/node-22.json
@@ -1,23 +1,23 @@
 {
   "schema": "tritium.compatibility-receipt.v1",
   "target_id": "node-22",
-  "source_revision": "29503cef202f83cb042930379209b7ebae005d35",
+  "source_revision": "62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
   "passed": true,
   "install_smoke": true,
   "host_os": "linux",
   "host_arch": "x64",
   "toolchain": {
-    "node": "v24.18.1",
+    "node": "v22.22.2",
     "npm": "12.0.0"
   },
   "package": "@tritium-ai/web@1.1.0-rc.1",
   "archive": "tritium-ai-web-1.1.0-rc.1.tgz",
-  "archive_sha256": "f329eb0a6f734b1c5ee68bed5e2873fb6eee5ab0331539e135b27e9a9720f796",
-  "archive_bytes": 638947,
+  "archive_sha256": "fb415dc7685d3cd4ad141153dd8a2717d9be1c9493ab7102cf48187bfa7e98eb",
+  "archive_bytes": 638084,
   "source_free": true,
   "installed_offline": true,
   "strict_typescript": true,
-  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:29503cef202f83cb042930379209b7ebae005d35",
-  "wasm_guest_digest": "17c7a4da9e824a9ad1113a0c8aa11c6f1154a818d8f4189c73266f1dd0d1643c",
-  "upstream_receipt_id": "sha256:3b28313435345e6d9c6c3c729c620305ca964f888bf81d1e8a4f21bad1a05726"
+  "wasm_build_id": "tritium-wasm@1.1.0-rc.1+source-git:62a95a37fd99cab192c7af2bd7cdfa4e9b4fd830",
+  "wasm_guest_digest": "14c95330845568ae71af2a5013045341b0906071e47feed69105dfe1683c6272",
+  "upstream_receipt_id": "sha256:089092af10fe0d3bb614404a10ed1829c6ad52dee4a2a8747f2806b5cb3ebd1a"
 }

--- a/scripts/aggregate-wheel-smoke.py
+++ b/scripts/aggregate-wheel-smoke.py
@@ -24,7 +24,11 @@ VERSIONS = {
 TARGET_CONTRACTS = {
     "linux-x86_64-cpu": ("linux", {"x86_64", "amd64"}, r"manylinux.*_x86_64"),
     "windows-x86_64-cpu": ("win32", {"x86_64", "amd64"}, r"win_amd64"),
-    "macos-arm64-cpu": ("darwin", {"arm64", "aarch64"}, r"macosx_.*_universal2"),
+    "macos-arm64-cpu": (
+        "darwin",
+        {"arm64", "aarch64"},
+        r"macosx_.*_(?:arm64|universal2)",
+    ),
 }
 FIELDS = {
     "schema",

--- a/scripts/tests/test_aggregate_wheel_smoke.py
+++ b/scripts/tests/test_aggregate_wheel_smoke.py
@@ -53,6 +53,20 @@ class AggregateWheelSmokeTests(unittest.TestCase):
             self.assertEqual(receipt["target_id"], MODULE.TARGET_ID)
             self.assertEqual(len(receipt["cells"]), len(MODULE.expected_cells()))
 
+    def test_native_macos_arm64_platform_passes(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            write_matrix(root)
+            for path in root.glob("macos-arm64-cpu-*.json"):
+                value = json.loads(path.read_text())
+                value["platform_tag"] = "macosx_11_0_arm64"
+                value["wheel"] = value["wheel"].replace(
+                    "macosx_11_0_universal2", "macosx_11_0_arm64"
+                )
+                path.write_text(json.dumps(value), encoding="utf-8")
+            receipt = MODULE.aggregate(root, REVISION, RELEASE, "run-arm64")
+            self.assertTrue(receipt["passed"])
+
     def test_missing_cell_fails(self):
         with tempfile.TemporaryDirectory() as raw:
             root = Path(raw)

--- a/scripts/tests/test_installed_qat_tutorial.py
+++ b/scripts/tests/test_installed_qat_tutorial.py
@@ -33,17 +33,13 @@ class InstalledQatTutorialTests(unittest.TestCase):
         self.assertIn("container: python:3.13-slim", job)
         self.assertNotIn("actions/checkout", job)
         self.assertIn('test ! -e "$GITHUB_WORKSPACE/.git"', job)
-        for compiler in (
-            "cargo",
-            "rustc",
-            "cc",
-            "c++",
-            "gcc",
-            "g++",
-            "clang",
-            "clang++",
-        ):
-            self.assertIn(f"! command -v {compiler}", job)
+        self.assertIn(
+            "for compiler in cargo rustc cc c++ gcc g++ clang clang++; do", job
+        )
+        self.assertIn('if command -v "$compiler" >/dev/null 2>&1; then', job)
+        self.assertIn(
+            "compiler must be absent in source-free lane: $compiler", job
+        )
         self.assertIn("python -I -m tritium.torch.tutorial_qat", job)
         self.assertIn("--check-receipt", job)
         self.assertIn("test_tutorial_qat.py", workflow)


### PR DESCRIPTION
## Outcome

Complete Tritium repository hardening by adding workflow-definition lint to the required CI gate. Base governance controls are already on `main` from the preceding hardening commit.

## This PR

- add pinned `actionlint` with custom self-hosted labels in `.github/actionlint.yaml`;
- require `workflow-lint` from `ci-required`.

Base commit already on `main`:

- root `AGENTS.md` with fail-closed evidence, generated-file, ADR, and independent-review rules;
- root CODEOWNERS coverage;
- weekly Cargo/npm/Actions Dependabot updates;
- read-only workflow token permissions and concurrency cancellation.

## Verification

- `git diff --check`
- Ruby YAML parse for workflow/config files
- `actionlint`
- pre-commit staged-tree gate passed
- pre-push fmt, workspace clippy, and GPU-feature clippy legs passed

## Merge gates

Protected-main ruleset requires one code-owner approval plus `ci-required`, `docs-required`, and `capstone-required`. No bypass actors.
