### PR TITLE
feat: `tritium convert` — model-aware SALT conversion with the salience fold (ADR 0038 WS-3)

### DIFF
--- a/crates/tritium-cli/src/convert.rs
+++ b/crates/tritium-cli/src/convert.rs
@@ -1,0 +1,515 @@
+//! `tritium convert` — model-aware SALT conversion: load → calibrate → fold → ladder-fit → bundle.
+//!
+//! # Why this is not a flag on `tritium quantize`
+//!
+//! `quantize` reads a bare safetensors file. That is enough to fit weights, and it is exactly why
+//! the artifact it writes is a *different configuration* from every published SALT number: those
+//! were all measured under the AWQ-style salience fold, which needs activation statistics from a
+//! calibration corpus and, more importantly, needs the **layer graph**.
+//!
+//! The fold scales the columns of each projection by a per-input-channel salience `s` and divides
+//! the *preceding norm* by the same `s`. The product is unchanged — it is an exact
+//! reparameterisation — but only if both halves are applied. Knowing which norm feeds which
+//! projection is a property of the model, not of any tensor, so the fold has to run on a loaded
+//! model. Hence a separate command.
+//!
+//! Measured value of the fold on SmolLM2-360M: **2.3× at T=2, 8.5% at T=3, 1.1% at T=4**.
+//!
+//! # What the artifact has to contain, and why
+//!
+//! `ModelWeights::load_salt` reads the 2-D matrices from the SALT bundle and — in its own words —
+//! *"only 1D norms come from the fp master"*. A converter that wrote just a `.tslb` next to the
+//! original model would therefore produce a model that **loads and is silently wrong**: the
+//! weights would carry the fold and the norms would not.
+//!
+//! So `convert` writes a self-contained output directory:
+//!
+//! | file | contents |
+//! |---|---|
+//! | `config.json` | copied verbatim from the source |
+//! | `model.safetensors` | the fp 1-D norms, **after** the fold |
+//! | `model.tslb` | the SALT bundle: embedding + every projection |
+//! | tokenizer assets | copied when present, so the directory is usable on its own |
+//!
+//! This is the same asymmetry that makes the Hadamard rotation unrepresentable — a rotated fit
+//! reconstructs `W·H` and the bundle has nowhere to record `H`. The fold escapes it only because
+//! its other half lands in a tensor the format already carries. Rotation stays off here for
+//! exactly that reason.
+//!
+//! # Reading the fidelity receipt
+//!
+//! `convert` writes `receipt.json` by default: the resolved recipe, the byte cost, and per-tensor
+//! relative Frobenius error decoded from the artifact that was just written (so f16 block-scale
+//! rounding is included, not idealised away).
+//!
+//! **That error is not a quality ranking across recipes.** Measured on SmolLM2-135M at T=4:
+//! `--fold-alpha 0` gives 0.0252 and `--fold-alpha 0.75` gives **0.0380** — the fold is 51% worse
+//! by weight-space error while being better by perplexity, because it deliberately moves error to
+//! where activations are small. The same inversion is already on record here for per-group plane
+//! allocation: 12.4% lower weight SSE, 12% *worse* perplexity. The receipt says so in its own
+//! `interpretation` field, since that file is what a downstream consumer reads.
+//!
+//! # Configuration that has never been measured
+//!
+//! Fold-without-rotation is a *new* point: the published numbers are fold **and** rotation, and
+//! `quantize`'s numbers are neither. The measured anchors for the no-fold/no-rotation path this
+//! shares are 1.335× fp at T=3 and 1.024× at T=4 (SmolLM2-360M, g256). What the fold is worth on
+//! top of those is not yet known, so this command reports its recipe and makes no quality claim.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use tritium_format::{SaltRow, salt_rows_to_dense, write_salt_bundle};
+use tritium_nn::calibrate::{Calib, calibrate, extract, fold, norm_tensors, weight_names};
+use tritium_nn::{HfJsonTokenizer, ModelRunner, Tokenizer};
+
+use crate::quantize_ladder::{LadderConfig, quantize_tensor_ladder};
+
+/// Calibration window length. Matches the research harness's `EVAL_WINDOW` so a `convert` run and
+/// a harness run see the same context structure; the fold only reads per-channel second moments,
+/// which are not sensitive to this, but keeping them equal removes a variable when comparing.
+const CALIB_WINDOW: usize = 512;
+
+/// Tokenizer assets copied through so the output directory stands alone. Missing ones are skipped
+/// without comment — not every source snapshot has all of them.
+const TOKENIZER_ASSETS: [&str; 5] = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "vocab.json",
+    "merges.txt",
+];
+
+/// Resolved conversion settings.
+pub(crate) struct ConvertConfig {
+    pub(crate) calib: Option<PathBuf>,
+    pub(crate) calib_tokens: usize,
+    pub(crate) fold_alpha: f64,
+    pub(crate) ladder: LadderConfig,
+}
+
+pub(crate) fn run(model: &Path, out: &Path, cfg: &ConvertConfig) -> Result<()> {
+    cfg.ladder.validate()?;
+    if !(0.0..=1.0).contains(&cfg.fold_alpha) {
+        bail!(
+            "--fold-alpha must be in [0, 1] (0 = identity fold, 1 = full salience); got {}",
+            cfg.fold_alpha
+        );
+    }
+    if cfg.calib.is_none() && cfg.fold_alpha != 0.0 {
+        bail!(
+            "--fold-alpha {} was requested but there is no calibration corpus to measure salience \
+             from. Pass --calib <corpus>, or --fold-alpha 0 to convert without the fold (which is \
+             what `tritium quantize` already does).",
+            cfg.fold_alpha
+        );
+    }
+
+    let runner = ModelRunner::from_hf(model, Box::new(tritium_cpu::CpuBackend::new()))
+        .with_context(|| format!("load fp model {}", model.display()))?;
+    let (arch, fp, shapes) = extract(&runner);
+    let names = weight_names(&arch);
+    if names.len() != fp.len() {
+        bail!(
+            "internal: {} weight names for {} weights — weight_names and extract have drifted",
+            names.len(),
+            fp.len()
+        );
+    }
+
+    // Fold first: it rewrites both the weights and the norms, and the ladder must fit the folded
+    // weights, not the originals.
+    let (weights, arch, fold_desc) = match &cfg.calib {
+        Some(path) => {
+            let tokens = load_calibration_tokens(path, model, cfg.calib_tokens, arch.vocab)?;
+            let windows = tokens.len() / CALIB_WINDOW;
+            if windows == 0 {
+                bail!(
+                    "calibration corpus {} has {} tokens, need at least {CALIB_WINDOW} for one \
+                     window",
+                    path.display(),
+                    tokens.len()
+                );
+            }
+            let mut acc = Calib::new(&arch);
+            for w in 0..windows {
+                calibrate(
+                    &fp,
+                    &arch,
+                    &tokens[w * CALIB_WINDOW..(w + 1) * CALIB_WINDOW],
+                    &mut acc,
+                );
+            }
+            let (w, arch) = fold(&fp, &shapes, &arch, &acc, cfg.fold_alpha);
+            (
+                w,
+                arch,
+                format!(
+                    "salience fold alpha={} over {windows} x {CALIB_WINDOW} calibration tokens",
+                    cfg.fold_alpha
+                ),
+            )
+        }
+        None => (fp, arch, "no calibration fold".to_owned()),
+    };
+
+    // Fit every projection with the ladder. `shapes[i]` is `(n_out, k_in)` for `weights[i]`.
+    let mut quantized: Vec<(String, Vec<SaltRow>)> = Vec::with_capacity(weights.len());
+    let mut total_params = 0usize;
+    let mut fidelity: Vec<TensorFidelity> = Vec::with_capacity(weights.len());
+    for ((name, w), &(rows, k)) in names.iter().zip(&weights).zip(&shapes) {
+        if w.len() != rows * k {
+            bail!("{name}: {} values for shape [{rows}, {k}]", w.len());
+        }
+        let fitted = quantize_tensor_ladder(w, rows, k, &cfg.ladder)
+            .with_context(|| format!("ladder-quantize {name}"))?;
+        // Score the PACKED rows, not a re-run of the fitter: the f16 block scales are rounded on
+        // the way into TQ2_0, so decoding the artifact is the only way to report the error the
+        // user's file actually has rather than the one the fit intended.
+        let decoded = salt_rows_to_dense(&fitted)
+            .map_err(|e| anyhow::anyhow!("decode {name} for the fidelity receipt: {e}"))?;
+        fidelity.push(TensorFidelity::measure(name, rows, k, w, &decoded)?);
+        total_params += rows * k;
+        quantized.push((name.clone(), fitted));
+    }
+
+    std::fs::create_dir_all(out).with_context(|| format!("create {}", out.display()))?;
+
+    let refs: Vec<(&str, &[SaltRow])> = quantized
+        .iter()
+        .map(|(n, r)| (n.as_str(), r.as_slice()))
+        .collect();
+    let bundle = write_salt_bundle(&refs).context("serialize SALT bundle")?;
+    let bundle_path = out.join("model.tslb");
+    std::fs::write(&bundle_path, &bundle)
+        .with_context(|| format!("write {}", bundle_path.display()))?;
+
+    // The folded norms. Without these the bundle above reconstructs a model whose weights carry a
+    // fold its norms do not — a wrong model that loads cleanly.
+    let norms = norm_tensors(&arch);
+    let norms_path = out.join("model.safetensors");
+    std::fs::write(&norms_path, write_f32_safetensors(&norms))
+        .with_context(|| format!("write {}", norms_path.display()))?;
+
+    let config_src = model.join("config.json");
+    std::fs::copy(&config_src, out.join("config.json"))
+        .with_context(|| format!("copy {}", config_src.display()))?;
+    let mut copied_assets = 0usize;
+    for asset in TOKENIZER_ASSETS {
+        let src = model.join(asset);
+        if src.exists() {
+            std::fs::copy(&src, out.join(asset))
+                .with_context(|| format!("copy {}", src.display()))?;
+            copied_assets += 1;
+        }
+    }
+
+    let receipt_path = out.join("receipt.json");
+    let whole_model_error = write_receipt(
+        &receipt_path,
+        model,
+        cfg,
+        &fold_desc,
+        &fidelity,
+        total_params,
+        bundle.len(),
+    )?;
+
+    // Load the artifact back before claiming success. Every failure mode this command can have —
+    // a tensor name the loader does not look up, a shape the bundle disagrees with, a norm written
+    // under the wrong key — produces a file that is *structurally valid* and simply never resolves.
+    // A converter that reports success without reloading cannot tell those apart from a good run.
+    ModelRunner::from_salt(out, &bundle_path, Box::new(tritium_cpu::CpuBackend::new()))
+        .with_context(|| {
+            format!(
+                "the converted model at {} did not load back — the artifact is written but not \
+                 usable",
+                out.display()
+            )
+        })?;
+
+    let bpw = cfg.ladder.realizable_bpw();
+    println!(
+        "converted {} tensors ({:.2}M params) | ladder geometric, {} planes, g{}, grid {}, no \
+         rotation, {fold_desc} → {} ({:.1} MiB bundle + {:.1} KiB norms + config + {copied_assets} \
+         tokenizer files, {bpw:.4} bpw)",
+        names.len(),
+        total_params as f64 / 1e6,
+        cfg.ladder.planes,
+        cfg.ladder.group,
+        cfg.ladder.grid,
+        out.display(),
+        bundle.len() as f64 / (1024.0 * 1024.0),
+        norms.iter().map(|(_, v)| v.len() * 4).sum::<usize>() as f64 / 1024.0,
+    );
+    println!(
+        "  fidelity: {:.4} relative Frobenius error whole-model, measured on the decoded artifact \
+         (per-tensor breakdown in {})",
+        whole_model_error,
+        receipt_path.display()
+    );
+    println!("  verified: reloaded from {}", out.display());
+    Ok(())
+}
+
+/// Reconstruction fidelity of one tensor, measured on the decoded artifact.
+struct TensorFidelity {
+    name: String,
+    rows: usize,
+    cols: usize,
+    /// `‖W − Ŵ‖_F / ‖W‖_F`. Scale-free, so tensors of very different magnitudes are comparable —
+    /// which raw SSE is not, and which is the whole point of reporting this per tensor.
+    relative_frobenius: f64,
+    /// `Σ(W − Ŵ)²` and `Σ W²`, kept so the whole-model figure is a true aggregate rather than an
+    /// average of ratios (which would weight a 576-element tensor like a 100M-element one).
+    sq_error: f64,
+    sq_weight: f64,
+}
+
+impl TensorFidelity {
+    fn measure(name: &str, rows: usize, cols: usize, w: &[f32], decoded: &[f32]) -> Result<Self> {
+        if decoded.len() != w.len() {
+            bail!(
+                "{name}: decoded {} values for a {}-value tensor — the packer and the decoder \
+                 disagree about this tensor's layout",
+                decoded.len(),
+                w.len()
+            );
+        }
+        let mut sq_error = 0.0f64;
+        let mut sq_weight = 0.0f64;
+        for (&a, &b) in w.iter().zip(decoded) {
+            let d = f64::from(a) - f64::from(b);
+            sq_error += d * d;
+            sq_weight += f64::from(a) * f64::from(a);
+        }
+        Ok(Self {
+            name: name.to_owned(),
+            rows,
+            cols,
+            relative_frobenius: if sq_weight > 0.0 {
+                (sq_error / sq_weight).sqrt()
+            } else {
+                0.0
+            },
+            sq_error,
+            sq_weight,
+        })
+    }
+}
+
+/// Write the fidelity receipt.
+///
+/// Emitted by default rather than behind a flag: a quantized model with no record of *how* it was
+/// quantized and *how much* it lost is the thing that makes quantized checkpoints untrustworthy,
+/// and the receipt is cheap — it is decoded from the artifact that was just written.
+#[allow(clippy::too_many_arguments)]
+fn write_receipt(
+    path: &Path,
+    source: &Path,
+    cfg: &ConvertConfig,
+    fold_desc: &str,
+    fidelity: &[TensorFidelity],
+    total_params: usize,
+    bundle_bytes: usize,
+) -> Result<f64> {
+    let sq_error: f64 = fidelity.iter().map(|f| f.sq_error).sum();
+    let sq_weight: f64 = fidelity.iter().map(|f| f.sq_weight).sum();
+    let whole_model = if sq_weight > 0.0 {
+        (sq_error / sq_weight).sqrt()
+    } else {
+        0.0
+    };
+
+    let tensors: Vec<serde_json::Value> = fidelity
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "name": f.name,
+                "shape": [f.rows, f.cols],
+                "relative_frobenius_error": f.relative_frobenius,
+            })
+        })
+        .collect();
+
+    let receipt = serde_json::json!({
+        "source": {
+            "directory": source.display().to_string(),
+            "config_sha256": file_digest(&source.join("config.json"))?,
+        },
+        "recipe": {
+            "fitter": "geometric ladder",
+            "planes": cfg.ladder.planes,
+            "group": cfg.ladder.group,
+            "grid": cfg.ladder.grid,
+            // Recorded explicitly because its absence is load-bearing: the SALT bundle has nowhere
+            // to store a rotation matrix, so a rotated fit would reconstruct W*H instead of W.
+            "rotation": "none",
+            "fold_alpha": if cfg.calib.is_some() { cfg.fold_alpha } else { 0.0 },
+            "calibration": fold_desc,
+        },
+        "cost": {
+            "parameters": total_params,
+            "bits_per_weight": cfg.ladder.realizable_bpw(),
+            "bundle_bytes": bundle_bytes,
+            "container": "TQ2_0 planes (2 bits/trit + one f16 scale per 256)",
+        },
+        "fidelity": {
+            "whole_model_relative_frobenius_error": whole_model,
+            "measured_on": "the decoded artifact, including f16 block-scale rounding",
+            // Load-bearing caveat, in the artifact rather than only in the docs, because the
+            // receipt is what a downstream consumer actually reads. Measured on SmolLM2-135M at
+            // T=4: alpha=0 gives 0.0252 and alpha=0.75 gives 0.0380 -- the fold is 51% WORSE by
+            // this metric while being better by perplexity, because it deliberately trades
+            // weight-space error for error where activations are large. This repo has already
+            // measured the same inversion for per-group plane allocation (12.4% lower weight SSE,
+            // 12% worse perplexity). Comparing this number across recipes ranks them backwards.
+            "interpretation": "Weight-space error against the fp master. Valid for comparing \
+                               TENSORS within this model, and for detecting a corrupt conversion. \
+                               NOT a quality ranking across recipes: a larger fold_alpha \
+                               increases this number and improves perplexity, because the fold \
+                               trades weight-space error for error where activations are small.",
+            "tensors": tensors,
+        },
+    });
+
+    std::fs::write(path, serde_json::to_vec_pretty(&receipt)?)
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(whole_model)
+}
+
+fn file_digest(path: &Path) -> Result<String> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    Ok(format!(
+        "{:x}",
+        <sha2::Sha256 as sha2::Digest>::digest(&bytes)
+    ))
+}
+
+/// Load calibration token ids.
+///
+/// Two accepted forms, distinguished by content rather than by extension so a renamed file cannot
+/// be silently misread:
+///
+/// - a JSON object with a `train_ids` array of integers — the format the research corpora use, so
+///   a `convert` run can be compared against a harness run on identical tokens;
+/// - anything else: UTF-8 text, tokenized with the source model's `tokenizer.json`.
+fn load_calibration_tokens(
+    path: &Path,
+    model: &Path,
+    limit: usize,
+    vocab: usize,
+) -> Result<Vec<u32>> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+
+    let ids: Vec<u32> = if let Some(ids) = parse_train_ids(&bytes)? {
+        ids
+    } else {
+        let text = String::from_utf8(bytes).with_context(|| {
+            format!(
+                "{} is neither a corpus JSON with `train_ids` nor UTF-8 text",
+                path.display()
+            )
+        })?;
+        tokenize_with_model(model, &text)?
+    };
+
+    if let Some(&bad) = ids.iter().find(|&&id| id as usize >= vocab) {
+        bail!(
+            "calibration corpus {} contains token id {bad}, outside the model's vocabulary of \
+             {vocab} — it was tokenized for a different model",
+            path.display()
+        );
+    }
+    Ok(ids.into_iter().take(limit).collect())
+}
+
+/// Recognize the research corpus format. `Ok(None)` means "not that format"; an error means it
+/// looked like one and was malformed, which is worth reporting rather than falling through to a
+/// nonsense tokenization.
+fn parse_train_ids(bytes: &[u8]) -> Result<Option<Vec<u32>>> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return Ok(None);
+    };
+    let Some(array) = value.get("train_ids") else {
+        return Ok(None);
+    };
+    let array = array
+        .as_array()
+        .context("corpus JSON has `train_ids` but it is not an array")?;
+    array
+        .iter()
+        .map(|v| {
+            v.as_u64()
+                .and_then(|n| u32::try_from(n).ok())
+                .context("`train_ids` must contain non-negative integers that fit in u32")
+        })
+        .collect::<Result<Vec<u32>>>()
+        .map(Some)
+}
+
+/// Tokenize raw calibration text with the **source model's own** tokenizer.
+///
+/// Using the model's tokenizer rather than any default is not a convenience: token ids are only
+/// meaningful relative to the vocabulary they were produced for, and calibrating on ids from a
+/// different tokenizer would measure the activation statistics of gibberish while looking
+/// perfectly healthy.
+fn tokenize_with_model(model: &Path, text: &str) -> Result<Vec<u32>> {
+    let tokenizer_json = model.join("tokenizer.json");
+    let tokenizer_config = model.join("tokenizer_config.json");
+    if !tokenizer_json.exists() {
+        bail!(
+            "calibration text needs a tokenizer, but {} has no tokenizer.json. Pass a corpus JSON \
+             with a `train_ids` array instead (the format under ~/.cache/tritium-corpora).",
+            model.display()
+        );
+    }
+    let tokenizer = HfJsonTokenizer::from_files(&tokenizer_json, &tokenizer_config)
+        .with_context(|| format!("load tokenizer from {}", model.display()))?;
+    tokenizer
+        .encode(text)
+        .map_err(|e| anyhow::anyhow!("tokenize calibration text: {e}"))
+}
+
+/// Minimal f32 safetensors writer for the fp side-file.
+///
+/// Deliberately not reusing a general writer: this file has exactly one job — carry the 1-D norms
+/// that `load_salt` reads from the fp master — and every tensor in it is a 1-D f32 vector.
+fn write_f32_safetensors(tensors: &[(String, &[f32])]) -> Vec<u8> {
+    // BTreeMap so the header is deterministic: two runs on the same model produce byte-identical
+    // files, which is what makes an artifact diffable and hashable.
+    let mut entries: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    let mut offset = 0usize;
+    for (name, values) in tensors {
+        let end = offset + values.len() * 4;
+        entries.insert(name.as_str(), (offset, end));
+        offset = end;
+    }
+
+    let header = entries
+        .iter()
+        .map(|(name, (start, end))| {
+            format!(
+                r#""{name}":{{"dtype":"F32","shape":[{}],"data_offsets":[{start},{end}]}}"#,
+                (end - start) / 4
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let mut header = format!("{{{header}}}").into_bytes();
+    while header.len() % 8 != 0 {
+        header.push(b' ');
+    }
+
+    let mut out = Vec::with_capacity(8 + header.len() + offset);
+    out.extend_from_slice(&(header.len() as u64).to_le_bytes());
+    out.extend_from_slice(&header);
+    // Payload order must match the offsets, which came from `tensors` order, not the sorted header.
+    for (_, values) in tensors {
+        for &v in *values {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    out
+}

--- a/crates/tritium-cli/src/main.rs
+++ b/crates/tritium-cli/src/main.rs
@@ -38,6 +38,7 @@ mod campaign;
 mod campaign_artifact;
 #[cfg(feature = "nccl")]
 mod campaign_world;
+mod convert;
 mod generate;
 #[cfg(feature = "cuda")]
 mod hestia_gate;
@@ -154,6 +155,41 @@ enum Command {
         /// Transport operation.
         #[command(subcommand)]
         transport: transport::TransportCommand,
+    },
+    /// Convert a Hugging Face fp model directory to a ready-to-run ternary model directory.
+    ///
+    /// Unlike `quantize`, this loads the whole model, so it can run the activation-aware salience
+    /// fold (`--calib`) — the lever every published SALT number was measured under — and it writes
+    /// the folded norms alongside the bundle. Writing only a bundle would produce a model whose
+    /// weights carry the fold and whose norms do not.
+    Convert {
+        /// Hugging Face model directory (config.json + safetensors shards).
+        #[arg(long)]
+        model: PathBuf,
+        /// Output directory: config.json + model.safetensors (folded norms) + model.tslb.
+        #[arg(long)]
+        out: PathBuf,
+        /// Calibration corpus for the salience fold: either a corpus JSON with a `train_ids`
+        /// array, or a UTF-8 text file tokenized with the model's own tokenizer. Without it the
+        /// fold is skipped and the result matches `tritium quantize`.
+        #[arg(long)]
+        calib: Option<PathBuf>,
+        /// Calibration tokens to use (rounded down to whole 512-token windows).
+        #[arg(long, default_value_t = 4096)]
+        calib_tokens: usize,
+        /// Salience-fold strength. 0.75 is the value every published SALT number used, but the
+        /// optimum shifts DOWN with model size (0.75 -> 0.50 observed), so it is worth sweeping.
+        #[arg(long, default_value_t = 0.75)]
+        fold_alpha: f64,
+        /// Plane count. 4 measures 1.024x fp on SmolLM2-360M without any fold; 3 measures 1.335x.
+        #[arg(long, default_value_t = 4)]
+        planes: usize,
+        /// Scale-group width. Must be a multiple of 256 (one f16 scale per TQ2_0 block).
+        #[arg(long, default_value_t = 256)]
+        group: usize,
+        /// Delta candidates per group for the ladder's `s0` grid search.
+        #[arg(long, default_value_t = 16)]
+        grid: usize,
     },
     /// SALT-quantize an fp safetensors model to a SALT bundle.
     Quantize {
@@ -484,6 +520,29 @@ fn main() -> anyhow::Result<()> {
                 format,
             )?,
         },
+        Command::Convert {
+            model,
+            out,
+            calib,
+            calib_tokens,
+            fold_alpha,
+            planes,
+            group,
+            grid,
+        } => convert::run(
+            &model,
+            &out,
+            &convert::ConvertConfig {
+                calib,
+                calib_tokens,
+                fold_alpha,
+                ladder: quantize_ladder::LadderConfig {
+                    planes,
+                    group,
+                    grid,
+                },
+            },
+        )?,
         Command::Quantize {
             input,
             output,

--- a/crates/tritium-cli/tests/convert_roundtrip.rs
+++ b/crates/tritium-cli/tests/convert_roundtrip.rs
@@ -5,28 +5,33 @@
 //! loader does not look up, a shape the bundle disagrees with. That check cannot catch a *numeric*
 //! error, and this command has one specific way to be numerically wrong:
 //!
-//! The salience fold scales projection columns by `s` and divides the preceding norm by `s`. Both
-//! halves land in different files — the weights in `model.tslb`, the norms in `model.safetensors`.
-//! If the norm half were dropped, mis-keyed, or written for the wrong layer, the artifact would
-//! load perfectly and evaluate as a **badly damaged model**. Nothing structural distinguishes that
-//! from a good run.
+//! The salience fold scales projection columns by `s` and divides the preceding norm by `s`. The
+//! two halves land in different files — the weights in `model.tslb`, the norms in
+//! `model.safetensors`. If the norm half were dropped, mis-keyed, or written for the wrong layer,
+//! the artifact would load perfectly and evaluate as a **badly damaged model**. Nothing structural
+//! distinguishes that from a good run.
 //!
-//! So this scores the converted model on held-out text and compares it against measured anchors.
+//! # Everything here is a ratio, and that is the point
 //!
-//! # Anchors (SmolLM2-360M, WikiText-2 held-out, g256, no rotation)
+//! The first version of this test asserted an absolute perplexity against 15.268, a number the
+//! research harness measured. It failed by 26%, and **none of that was a defect in `convert`**.
+//! `convert_anchor_diagnostic` decomposed it:
 //!
-//! | configuration | perplexity | ×fp |
+//! | step | factor | cause |
 //! |---|---|---|
-//! | fp16 master | 14.909 | 1.000 |
-//! | ladder T=4, **no fold** | 15.268 | 1.024 |
+//! | eval slice | 1.223× | the first 8,192 tokens are harder than the full 32,768 |
+//! | evaluator | 1.000× | the tape and `ModelRunner` agree exactly on fp weights |
+//! | fit → artifact bytes | 1.0003× | f16 block-scale rounding, at the floor |
+//! | artifact → runtime | 1.0276× | **int8 activations** |
 //!
-//! `convert --fold-alpha 0` must reproduce the no-fold row: it runs the identical fitter on
-//! identical weights, so a difference means the *writer* changed the values.
+//! That last row is not a bug and not this test's business, but it is why an anchor from the
+//! research harness cannot be asserted here: `SaltLinear::forward` calls
+//! `quantize_activation_int8` before every projection, while the harness scores dense
+//! reconstructions through `Tape::dense_matmul` in fp32. The two measure genuinely different
+//! systems. **Every published SALT perplexity is W-ternary/A-fp32; this path is W-ternary/A-int8.**
 //!
-//! Fold-without-rotation has never been measured — the published numbers are fold **and** rotation.
-//! The test therefore asserts a bound rather than a target: the folded model must not be *worse*
-//! than the unfolded one by more than noise. A dropped norm half would blow through that by orders
-//! of magnitude, which is the failure this exists to catch.
+//! So the fp reference is measured **here**, through the same runner and the same slice, and every
+//! assertion is a ratio against it. A basis that is re-measured in-process cannot silently drift.
 //!
 //! ```text
 //! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-360m \
@@ -39,19 +44,22 @@ use std::process::Command;
 
 use tritium_nn::{ModelRunner, teacher_forced_perplexity_windows};
 
-/// Window length for scoring. Matches the research harness so the numbers are comparable.
+/// Window length for scoring. Matches the research harness so the shapes are comparable.
 const EVAL_WINDOW: usize = 512;
-/// Held-out tokens. The full 32,768-token eval split takes far longer than this test is worth;
-/// 8,192 is stable to well under the margins asserted here.
+/// Held-out tokens. The full 32,768-token split costs far more than this test is worth; because
+/// every assertion is a ratio measured on this same slice, the slice only has to be *consistent*,
+/// not representative.
 const EVAL_TOKENS: usize = 8192;
 
-/// Measured perplexity of the fp16 master, for the ×fp column in the printout.
-const FP_PPL: f64 = 14.909;
-/// Measured perplexity of ladder T=4 / g256 / no fold / no rotation.
-const UNFOLDED_ANCHOR: f64 = 15.268;
-/// How far the unfolded conversion may drift from its anchor. The fit is deterministic, so this is
-/// only absorbing the difference between this eval slice and the harness's.
-const ANCHOR_TOLERANCE: f64 = 0.10;
+/// Measured degradation of a `convert`-written T=4/g256 artifact relative to the fp master,
+/// **through the shipping runtime** (so int8 activations are included): 19.263 / 18.240.
+///
+/// Deliberately not the research anchor's 15.268/14.909 = 1.0241, which is the same weights with
+/// fp32 activations. This constant guards what a user actually runs.
+const RUNTIME_RATIO_T4: f64 = 1.0560;
+/// Tolerance on that ratio. The fit is deterministic and the slice is fixed, so this only absorbs
+/// floating-point ordering — a real writer defect moves the ratio by percent, not by 0.5%.
+const RATIO_TOLERANCE: f64 = 0.005;
 
 fn tritium_bin() -> PathBuf {
     let mut p = std::env::current_exe().expect("test exe");
@@ -90,8 +98,8 @@ fn convert(model: &Path, out: &Path, corpus: &Path, alpha: f64) {
         "--fold-alpha",
         &alpha.to_string(),
     ]);
-    // alpha = 0 is the identity fold, so a corpus would only cost time. Passing one anyway would
-    // also make the two arms differ in more than the knob under test.
+    // alpha = 0 is the identity fold, so a corpus would only cost time — and passing one anyway
+    // would make the two arms differ in more than the knob under test.
     if alpha != 0.0 {
         cmd.args(["--calib", corpus.to_str().unwrap()]);
     }
@@ -99,20 +107,24 @@ fn convert(model: &Path, out: &Path, corpus: &Path, alpha: f64) {
     assert!(status.success(), "convert failed at alpha={alpha}");
 }
 
-fn perplexity(dir: &Path, tokens: &[u32]) -> f64 {
-    let mut runner = ModelRunner::from_salt(
+fn score(mut runner: ModelRunner, tokens: &[u32]) -> f64 {
+    teacher_forced_perplexity_windows(&mut runner, tokens, EVAL_WINDOW)
+        .expect("score model")
+        .perplexity
+}
+
+fn score_converted(dir: &Path, tokens: &[u32]) -> f64 {
+    let runner = ModelRunner::from_salt(
         dir,
         &dir.join("model.tslb"),
         Box::new(tritium_cpu::CpuBackend::new()),
     )
     .unwrap_or_else(|e| panic!("load converted model {}: {e}", dir.display()));
-    teacher_forced_perplexity_windows(&mut runner, tokens, EVAL_WINDOW)
-        .expect("score converted model")
-        .perplexity
+    score(runner, tokens)
 }
 
 #[test]
-#[ignore = "needs a real fp master and corpus; minutes, not seconds"]
+#[ignore = "three full evaluations of a real model on CPU"]
 fn converted_model_scores_like_the_fitter_that_made_it() {
     let model = PathBuf::from(
         std::env::var("TRITIUM_MODEL_DIR").expect("set TRITIUM_MODEL_DIR to an fp model directory"),
@@ -127,44 +139,52 @@ fn converted_model_scores_like_the_fitter_that_made_it() {
     let unfolded_dir = root.join("unfolded");
     let folded_dir = root.join("folded");
 
+    // The reference, measured here rather than quoted: same runner, same slice, same window.
+    let fp = score(
+        ModelRunner::from_hf(&model, Box::new(tritium_cpu::CpuBackend::new()))
+            .expect("load fp master"),
+        &tokens,
+    );
+    println!("fp master                : {fp:.3}");
+
     convert(&model, &unfolded_dir, &corpus, 0.0);
-    let unfolded = perplexity(&unfolded_dir, &tokens);
+    let unfolded = score_converted(&unfolded_dir, &tokens);
     println!(
-        "convert --fold-alpha 0   : {unfolded:.3} ({:.3}x fp)",
-        unfolded / FP_PPL
+        "convert --fold-alpha 0   : {unfolded:.3} ({:.4}x fp)",
+        unfolded / fp
     );
 
     convert(&model, &folded_dir, &corpus, 0.75);
-    let folded = perplexity(&folded_dir, &tokens);
+    let folded = score_converted(&folded_dir, &tokens);
     println!(
-        "convert --fold-alpha 0.75: {folded:.3} ({:.3}x fp)",
-        folded / FP_PPL
+        "convert --fold-alpha 0.75: {folded:.3} ({:.4}x fp)",
+        folded / fp
     );
     println!(
-        "fold delta: {:+.3}% (fold-without-rotation; the published numbers are fold AND rotation)",
+        "fold delta: {:+.3}% (fold WITHOUT rotation, through int8 activations — a configuration \
+         no published number covers)",
         100.0 * (folded - unfolded) / unfolded
     );
 
-    // The unfolded arm runs the same fitter on the same weights as the measured anchor, so any
-    // difference is the writer, not the method.
-    let drift = (unfolded - UNFOLDED_ANCHOR).abs() / UNFOLDED_ANCHOR;
+    // The unfolded arm is a deterministic fit of unmodified weights, so its degradation against fp
+    // is a fixed property of the pipeline. Any movement is the writer.
+    let ratio = unfolded / fp;
     assert!(
-        drift <= ANCHOR_TOLERANCE,
-        "convert --fold-alpha 0 scored {unfolded:.3}, but ladder T=4/g256/no-fold/no-rotation \
-         measures {UNFOLDED_ANCHOR:.3} ({:.1}% off). The fit is deterministic, so this is the \
-         writer changing values, not the method.",
-        100.0 * drift
+        (ratio - RUNTIME_RATIO_T4).abs() <= RATIO_TOLERANCE,
+        "convert --fold-alpha 0 degraded fp by {ratio:.4}x, expected {RUNTIME_RATIO_T4:.4}x \
+         (+/-{RATIO_TOLERANCE}). The fit is deterministic and fp is re-measured in this same run, \
+         so this is the conversion pipeline changing values."
     );
 
-    // The fold's whole point is that it is an exact reparameterisation: weights scaled by `s`,
-    // preceding norm divided by `s`. If the norm half were dropped or mis-keyed the artifact would
-    // still load and would evaluate as a wrecked model. Bounding the regression catches that with
-    // enormous margin, without asserting a number nobody has measured.
+    // The fold is an exact reparameterisation: weights scaled by `s`, preceding norm divided by
+    // `s`. If the norm half were dropped or mis-keyed the artifact would still load and would
+    // evaluate as a wrecked model. Bounding the regression catches that with enormous margin,
+    // without asserting a fold-without-rotation number nobody has measured.
     assert!(
         folded <= unfolded * 1.05,
         "folding made the model {:.1}% WORSE ({folded:.3} vs {unfolded:.3}). The fold is an exact \
-         reparameterisation, so a real regression this size means one half of it is missing — \
-         most likely the folded norms in model.safetensors are not reaching the loader.",
+         reparameterisation, so a regression this size means one half of it is missing — most \
+         likely the folded norms in model.safetensors are not reaching the loader.",
         100.0 * (folded - unfolded) / unfolded
     );
 

--- a/crates/tritium-cli/tests/convert_roundtrip.rs
+++ b/crates/tritium-cli/tests/convert_roundtrip.rs
@@ -1,0 +1,172 @@
+//! **Does `tritium convert` produce a model that is correct, not merely loadable?**
+//!
+//! `convert` already reloads its own artifact before reporting success, which catches the whole
+//! class of "wrote a structurally valid file the loader never resolves" bugs — a tensor name the
+//! loader does not look up, a shape the bundle disagrees with. That check cannot catch a *numeric*
+//! error, and this command has one specific way to be numerically wrong:
+//!
+//! The salience fold scales projection columns by `s` and divides the preceding norm by `s`. Both
+//! halves land in different files — the weights in `model.tslb`, the norms in `model.safetensors`.
+//! If the norm half were dropped, mis-keyed, or written for the wrong layer, the artifact would
+//! load perfectly and evaluate as a **badly damaged model**. Nothing structural distinguishes that
+//! from a good run.
+//!
+//! So this scores the converted model on held-out text and compares it against measured anchors.
+//!
+//! # Anchors (SmolLM2-360M, WikiText-2 held-out, g256, no rotation)
+//!
+//! | configuration | perplexity | ×fp |
+//! |---|---|---|
+//! | fp16 master | 14.909 | 1.000 |
+//! | ladder T=4, **no fold** | 15.268 | 1.024 |
+//!
+//! `convert --fold-alpha 0` must reproduce the no-fold row: it runs the identical fitter on
+//! identical weights, so a difference means the *writer* changed the values.
+//!
+//! Fold-without-rotation has never been measured — the published numbers are fold **and** rotation.
+//! The test therefore asserts a bound rather than a target: the folded model must not be *worse*
+//! than the unfolded one by more than noise. A dropped norm half would blow through that by orders
+//! of magnitude, which is the failure this exists to catch.
+//!
+//! ```text
+//! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-360m \
+//! TRITIUM_CORPUS=$HOME/.cache/tritium-corpora/wikitext2_400k_32k.json \
+//!   cargo test -p tritium-cli --release --test convert_roundtrip -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tritium_nn::{ModelRunner, teacher_forced_perplexity_windows};
+
+/// Window length for scoring. Matches the research harness so the numbers are comparable.
+const EVAL_WINDOW: usize = 512;
+/// Held-out tokens. The full 32,768-token eval split takes far longer than this test is worth;
+/// 8,192 is stable to well under the margins asserted here.
+const EVAL_TOKENS: usize = 8192;
+
+/// Measured perplexity of the fp16 master, for the ×fp column in the printout.
+const FP_PPL: f64 = 14.909;
+/// Measured perplexity of ladder T=4 / g256 / no fold / no rotation.
+const UNFOLDED_ANCHOR: f64 = 15.268;
+/// How far the unfolded conversion may drift from its anchor. The fit is deterministic, so this is
+/// only absorbing the difference between this eval slice and the harness's.
+const ANCHOR_TOLERANCE: f64 = 0.10;
+
+fn tritium_bin() -> PathBuf {
+    let mut p = std::env::current_exe().expect("test exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("tritium")
+}
+
+fn eval_tokens(path: &Path) -> Vec<u32> {
+    let bytes = std::fs::read(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let value: serde_json::Value = serde_json::from_slice(&bytes).expect("parse corpus json");
+    value["eval_ids"]
+        .as_array()
+        .expect("corpus has eval_ids")
+        .iter()
+        .map(|v| v.as_u64().expect("token id") as u32)
+        .take(EVAL_TOKENS)
+        .collect()
+}
+
+fn convert(model: &Path, out: &Path, corpus: &Path, alpha: f64) {
+    let _ = std::fs::remove_dir_all(out);
+    let mut cmd = Command::new(tritium_bin());
+    cmd.args([
+        "convert",
+        "--model",
+        model.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+        "--planes",
+        "4",
+        "--group",
+        "256",
+        "--fold-alpha",
+        &alpha.to_string(),
+    ]);
+    // alpha = 0 is the identity fold, so a corpus would only cost time. Passing one anyway would
+    // also make the two arms differ in more than the knob under test.
+    if alpha != 0.0 {
+        cmd.args(["--calib", corpus.to_str().unwrap()]);
+    }
+    let status = cmd.status().expect("run tritium convert");
+    assert!(status.success(), "convert failed at alpha={alpha}");
+}
+
+fn perplexity(dir: &Path, tokens: &[u32]) -> f64 {
+    let mut runner = ModelRunner::from_salt(
+        dir,
+        &dir.join("model.tslb"),
+        Box::new(tritium_cpu::CpuBackend::new()),
+    )
+    .unwrap_or_else(|e| panic!("load converted model {}: {e}", dir.display()));
+    teacher_forced_perplexity_windows(&mut runner, tokens, EVAL_WINDOW)
+        .expect("score converted model")
+        .perplexity
+}
+
+#[test]
+#[ignore = "needs a real fp master and corpus; minutes, not seconds"]
+fn converted_model_scores_like_the_fitter_that_made_it() {
+    let model = PathBuf::from(
+        std::env::var("TRITIUM_MODEL_DIR").expect("set TRITIUM_MODEL_DIR to an fp model directory"),
+    );
+    let corpus = PathBuf::from(
+        std::env::var("TRITIUM_CORPUS").expect("set TRITIUM_CORPUS to a corpus json"),
+    );
+    let tokens = eval_tokens(&corpus);
+    assert_eq!(tokens.len(), EVAL_TOKENS, "corpus is too small");
+
+    let root = std::env::temp_dir().join(format!("tritium-convert-rt-{}", std::process::id()));
+    let unfolded_dir = root.join("unfolded");
+    let folded_dir = root.join("folded");
+
+    convert(&model, &unfolded_dir, &corpus, 0.0);
+    let unfolded = perplexity(&unfolded_dir, &tokens);
+    println!(
+        "convert --fold-alpha 0   : {unfolded:.3} ({:.3}x fp)",
+        unfolded / FP_PPL
+    );
+
+    convert(&model, &folded_dir, &corpus, 0.75);
+    let folded = perplexity(&folded_dir, &tokens);
+    println!(
+        "convert --fold-alpha 0.75: {folded:.3} ({:.3}x fp)",
+        folded / FP_PPL
+    );
+    println!(
+        "fold delta: {:+.3}% (fold-without-rotation; the published numbers are fold AND rotation)",
+        100.0 * (folded - unfolded) / unfolded
+    );
+
+    // The unfolded arm runs the same fitter on the same weights as the measured anchor, so any
+    // difference is the writer, not the method.
+    let drift = (unfolded - UNFOLDED_ANCHOR).abs() / UNFOLDED_ANCHOR;
+    assert!(
+        drift <= ANCHOR_TOLERANCE,
+        "convert --fold-alpha 0 scored {unfolded:.3}, but ladder T=4/g256/no-fold/no-rotation \
+         measures {UNFOLDED_ANCHOR:.3} ({:.1}% off). The fit is deterministic, so this is the \
+         writer changing values, not the method.",
+        100.0 * drift
+    );
+
+    // The fold's whole point is that it is an exact reparameterisation: weights scaled by `s`,
+    // preceding norm divided by `s`. If the norm half were dropped or mis-keyed the artifact would
+    // still load and would evaluate as a wrecked model. Bounding the regression catches that with
+    // enormous margin, without asserting a number nobody has measured.
+    assert!(
+        folded <= unfolded * 1.05,
+        "folding made the model {:.1}% WORSE ({folded:.3} vs {unfolded:.3}). The fold is an exact \
+         reparameterisation, so a real regression this size means one half of it is missing — \
+         most likely the folded norms in model.safetensors are not reaching the loader.",
+        100.0 * (folded - unfolded) / unfolded
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/tritium-nn/src/calibrate.rs
+++ b/crates/tritium-nn/src/calibrate.rs
@@ -108,6 +108,45 @@ pub fn extract(runner: &ModelRunner) -> (Arch, Vec<Vec<f32>>, Vec<(usize, usize)
     (arch, fp, shapes)
 }
 
+/// HuggingFace tensor names for the weights [`extract`] returns, **in the same order**.
+///
+/// Anything that writes a quantized artifact has to label each matrix with the name the loader
+/// will look it up by, and [`extract`] returns a bare `Vec<Vec<f32>>`. Deriving the names in the
+/// consumer would mean a second copy of the naming convention living outside this crate, which is
+/// how a rename turns into an artifact that loads but is silently wired wrong. This delegates to
+/// the same `NameSchema` the loader itself uses, so there is exactly one spelling of each name.
+///
+/// Index 0 is the tied token embedding; then per layer `q, k, v, o, gate, up, down`.
+/// `extract_names_match_weights` pins the parallel to [`extract`].
+pub fn weight_names(a: &Arch) -> Vec<String> {
+    let schema = crate::model::NameSchema::Hf;
+    let mut names = vec![schema.top("token_embd").to_owned()];
+    for li in 0..a.n_layers {
+        for slot in ["q", "k", "v", "o", "gate", "up", "down"] {
+            names.push(schema.layer(li, slot));
+        }
+    }
+    names
+}
+
+/// HuggingFace names of the fp 1-D norms, paired with the [`Arch`] fields holding them.
+///
+/// These are the tensors [`fold`] modifies, and `ModelWeights::load_salt` reads them from the fp
+/// master rather than from the SALT bundle ("only 1D norms come from the fp master"). A converter
+/// that writes the bundle but not these norms produces a model that loads and is *wrong* — the
+/// weights carry the fold, the norms do not. Returned in `(name, values)` pairs so a writer cannot
+/// mis-pair them.
+pub fn norm_tensors(a: &Arch) -> Vec<(String, &[f32])> {
+    let schema = crate::model::NameSchema::Hf;
+    let mut out = Vec::with_capacity(2 * a.n_layers + 1);
+    for li in 0..a.n_layers {
+        out.push((schema.layer(li, "attn_norm"), a.attn_norms[li].as_slice()));
+        out.push((schema.layer(li, "ffn_norm"), a.ffn_norms[li].as_slice()));
+    }
+    out.push((schema.top("output_norm").to_owned(), a.out_norm.as_slice()));
+    out
+}
+
 /// The whole-model forward on the tape (validated bit-exact vs `ModelRunner` in
 /// `tape_model_conformance`): embed_gather → N GQA blocks → SwiGLU → tied head. `wids[0]` is the
 /// tied embed/head; then per layer `q,k,v,o,gate,up,down`. Returns `[tokens.len(), vocab]` logits.
@@ -291,4 +330,71 @@ pub fn fold(
         divide_rows(&mut w[base + 5], shapes[base + 5].1, &sd);
     }
     (w, arch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arch(n_layers: usize) -> Arch {
+        Arch {
+            attn_norms: vec![vec![1.0; 4]; n_layers],
+            ffn_norms: vec![vec![1.0; 4]; n_layers],
+            out_norm: vec![1.0; 4],
+            n_embd: 4,
+            n_head: 2,
+            n_head_kv: 1,
+            head_dim: 2,
+            ff: 8,
+            vocab: 16,
+            eps: 1e-5,
+            theta: 10_000.0,
+            n_layers,
+        }
+    }
+
+    /// `weight_names` has to stay parallel to `extract`, which pushes the tied embedding and then
+    /// seven projections per layer. Nothing in the type system enforces that; this does.
+    #[test]
+    fn weight_names_match_extract_layout() {
+        for n_layers in [1usize, 2, 5] {
+            assert_eq!(weight_names(&arch(n_layers)).len(), 1 + 7 * n_layers);
+        }
+    }
+
+    /// A rename in the loader's schema would otherwise show up as an artifact that writes fine and
+    /// resolves nothing — pin the exact strings the loader looks up.
+    #[test]
+    fn weight_names_are_the_hf_spellings() {
+        let names = weight_names(&arch(2));
+        assert_eq!(names[0], "model.embed_tokens.weight");
+        assert_eq!(names[1], "model.layers.0.self_attn.q_proj.weight");
+        assert_eq!(names[7], "model.layers.0.mlp.down_proj.weight");
+        assert_eq!(names[8], "model.layers.1.self_attn.q_proj.weight");
+    }
+
+    /// The norms are the half of the fold that lives outside the SALT bundle. Mis-pairing a name
+    /// with the wrong vector produces a model that loads and is wrong, so the pairing is returned
+    /// as tuples and asserted here.
+    #[test]
+    fn norm_tensors_pair_every_norm_with_its_name() {
+        let mut a = arch(2);
+        a.attn_norms[1] = vec![7.0; 4];
+        a.ffn_norms[0] = vec![9.0; 4];
+        let norms = norm_tensors(&a);
+        assert_eq!(norms.len(), 2 * 2 + 1);
+        let lookup = |name: &str| {
+            norms
+                .iter()
+                .find(|(n, _)| n == name)
+                .unwrap_or_else(|| panic!("missing {name}"))
+                .1
+        };
+        assert_eq!(lookup("model.layers.1.input_layernorm.weight")[0], 7.0);
+        assert_eq!(
+            lookup("model.layers.0.post_attention_layernorm.weight")[0],
+            9.0
+        );
+        assert_eq!(lookup("model.norm.weight").len(), 4);
+    }
 }

--- a/crates/tritium-nn/src/calibrate.rs
+++ b/crates/tritium-nn/src/calibrate.rs
@@ -1,0 +1,294 @@
+//! Activation calibration and the AWQ-style salience fold.
+//!
+//! **Promoted out of `crates/tritium-nn/tests/common/mod.rs`, where it lived for the whole SALT
+//! campaign.** Every published ladder number was measured under this fold at α = 0.75, yet nothing
+//! in the shipping tree could call it — `tritium quantize` reads a bare safetensors file and has no
+//! way to compute activation statistics. That gap is why the CLI's artifacts are a *different
+//! configuration* from the research runs (measured: the fold is worth 2.3× at T=2, 8.5% at T=3, and
+//! 1.1% at T=4). This module is the prerequisite for closing it.
+//!
+//! # Why this is model-aware, not a tensor op
+//!
+//! [`fold`] takes an [`Arch`] and **returns a modified one**: it scales weight columns by the
+//! per-channel salience and divides the *preceding norm* by the same factor, so the product is
+//! unchanged while the weights become easier to quantize. That requires knowing which norm feeds
+//! which projection — a property of the layer graph, not of any single tensor. Any command offering
+//! calibration therefore has to load a model, not a file of tensors.
+//!
+//! # Scope
+//!
+//! The Gram/curvature machinery (`Gram`, `GramSet`, `damped_inverse`, `calibrate_gram`) stays in the
+//! test tree deliberately: per-group curvature allocation was measured **negative** — 12.4% lower
+//! weight SSE and 12% worse perplexity at identical bits — so it is a research artifact, not a
+//! shipping path.
+//!
+//! `o_proj` is not calibrated. Its input is the attention concat, which under GQA has query heads
+//! sharing kv dims — exactly the case the salience fold also skips.
+
+use tritium_train::Tape;
+use tritium_train::nn::attention;
+use tritium_train::tape::ValueId;
+
+use crate::{Mlp, ModelRunner, Projection};
+
+/// Dims + fp 1D norms for the tape forward (the parts held fp, not quantized/trained).
+#[derive(Debug, Clone)]
+pub struct Arch {
+    pub attn_norms: Vec<Vec<f32>>,
+    pub ffn_norms: Vec<Vec<f32>>,
+    pub out_norm: Vec<f32>,
+    pub n_embd: usize,
+    pub n_head: usize,
+    pub n_head_kv: usize,
+    pub head_dim: usize,
+    pub ff: usize,
+    pub vocab: usize,
+    pub eps: f32,
+    pub theta: f32,
+    pub n_layers: usize,
+}
+
+/// Unwrap a `Dense` projection to `(weights, n_out, k_in)`. Panics on any compact projection:
+/// calibration reads the fp master, so a quantized model is a caller error, not a runtime case.
+pub fn dense(p: &Projection) -> (Vec<f32>, usize, usize) {
+    match p {
+        Projection::Dense(d) => (d.weights.clone(), d.n_out, d.k_in),
+        Projection::Salt(_)
+        | Projection::HostSaltV2(_)
+        | Projection::Ternary(_)
+        | Projection::Q2(_) => {
+            panic!("from_hf builds Dense projections")
+        }
+        #[cfg(feature = "cuda")]
+        Projection::SaltV2(_) => panic!("from_hf builds Dense projections"),
+    }
+}
+
+/// Extract the tape `Arch`, the flat fp weights (index 0 = tied token_embd, then per layer
+/// q,k,v,o,gate,up,down), and their `(n_out, k_in)` shapes from a loaded runner.
+pub fn extract(runner: &ModelRunner) -> (Arch, Vec<Vec<f32>>, Vec<(usize, usize)>) {
+    let cfg = &runner.config;
+    let w = &runner.weights;
+    assert!(w.lm_head.is_none(), "assumes tied lm-head");
+    let arch = Arch {
+        attn_norms: w.layers.iter().map(|b| b.attn_norm.clone()).collect(),
+        ffn_norms: w.layers.iter().map(|b| b.ffn_norm.clone()).collect(),
+        out_norm: w.output_norm.clone(),
+        n_embd: cfg.n_embd as usize,
+        n_head: cfg.n_head as usize,
+        n_head_kv: cfg.n_head_kv as usize,
+        head_dim: cfg.head_dim() as usize,
+        ff: match &w.layers[0].mlp {
+            Mlp::SwiGlu(m) => dense(&m.gate).1,
+            Mlp::Relu2(_) => panic!("SwiGLU"),
+        },
+        vocab: w.vocab,
+        eps: cfg.rms_eps,
+        theta: cfg.rope_theta,
+        n_layers: w.layers.len(),
+    };
+    let mut fp: Vec<Vec<f32>> = vec![
+        w.token_embd
+            .as_dense()
+            .expect("training reference requires dense token embedding")
+            .to_vec(),
+    ];
+    let mut shapes: Vec<(usize, usize)> = vec![(w.vocab, arch.n_embd)];
+    for b in w.layers.iter() {
+        let (gate, up, down) = match &b.mlp {
+            Mlp::SwiGlu(m) => (&m.gate, &m.up, &m.down),
+            Mlp::Relu2(_) => unreachable!(),
+        };
+        for p in [&b.q_proj, &b.k_proj, &b.v_proj, &b.o_proj, gate, up, down] {
+            let (wv, n, k) = dense(p);
+            fp.push(wv);
+            shapes.push((n, k));
+        }
+    }
+    (arch, fp, shapes)
+}
+
+/// The whole-model forward on the tape (validated bit-exact vs `ModelRunner` in
+/// `tape_model_conformance`): embed_gather → N GQA blocks → SwiGLU → tied head. `wids[0]` is the
+/// tied embed/head; then per layer `q,k,v,o,gate,up,down`. Returns `[tokens.len(), vocab]` logits.
+pub fn forward(t: &mut Tape, wids: &[ValueId], a: &Arch, tokens: &[u32]) -> ValueId {
+    let seq = tokens.len();
+    let mut hidden = t.embed_gather(wids[0], tokens, a.vocab, a.n_embd);
+    for li in 0..a.n_layers {
+        let base = 1 + 7 * li;
+        let an = t.leaf(a.attn_norms[li].clone());
+        let xn = t.rmsnorm(hidden, an, seq, a.n_embd, a.eps);
+        let attn = attention(
+            t,
+            xn,
+            wids[base],
+            wids[base + 1],
+            wids[base + 2],
+            wids[base + 3],
+            seq,
+            a.n_embd,
+            a.n_head,
+            a.n_head_kv,
+            a.head_dim,
+            a.theta,
+        );
+        hidden = t.add(hidden, attn);
+        let fnw = t.leaf(a.ffn_norms[li].clone());
+        let hn = t.rmsnorm(hidden, fnw, seq, a.n_embd, a.eps);
+        let g = t.dense_matmul(hn, wids[base + 4], seq, a.ff, a.n_embd);
+        let u = t.dense_matmul(hn, wids[base + 5], seq, a.ff, a.n_embd);
+        let ga = t.silu(g);
+        let gated = t.mul(ga, u);
+        let down = t.dense_matmul(gated, wids[base + 6], seq, a.n_embd, a.ff);
+        hidden = t.add(hidden, down);
+    }
+    let onw = t.leaf(a.out_norm.clone());
+    let fnorm = t.rmsnorm(hidden, onw, seq, a.n_embd, a.eps);
+    t.dense_matmul(fnorm, wids[0], seq, a.vocab, a.n_embd) // tied head
+}
+
+/// Per-input-channel second moments for the projections whose scale is foldable.
+#[derive(Debug, Clone)]
+pub struct Calib {
+    pub attn_in: Vec<Vec<f64>>, // [layer][n_embd] — input to q, k, v
+    pub ffn_in: Vec<Vec<f64>>,  // [layer][n_embd] — input to gate, up
+    pub down_in: Vec<Vec<f64>>, // [layer][ff]     — input to down
+    pub rows: usize,
+}
+
+impl Calib {
+    pub fn new(a: &Arch) -> Self {
+        Self {
+            attn_in: vec![vec![0.0; a.n_embd]; a.n_layers],
+            ffn_in: vec![vec![0.0; a.n_embd]; a.n_layers],
+            down_in: vec![vec![0.0; a.ff]; a.n_layers],
+            rows: 0,
+        }
+    }
+}
+
+/// Accumulate `Σ x²` per column of a `[seq, cols]` tape value.
+pub fn accumulate(t: &Tape, id: ValueId, seq: usize, cols: usize, acc: &mut [f64]) {
+    let v = t.value(id);
+    for r in 0..seq {
+        for (c, a) in acc.iter_mut().enumerate() {
+            let x = f64::from(v[r * cols + c]);
+            *a += x * x;
+        }
+    }
+}
+
+/// One calibration forward. Mirrors [`forward`] exactly, tapping the three foldable inputs.
+///
+/// Only the diagonal (`Σ x²` per channel) is accumulated, which is all the salience fold needs. The
+/// full Gram `Σ x xᵀ` that sequential error compensation would require stays in the test tree with
+/// the rest of the curvature machinery — see the module docs for why.
+pub fn calibrate(weights: &[Vec<f32>], a: &Arch, tokens: &[u32], c: &mut Calib) {
+    let mut t = Tape::new();
+    let wids: Vec<ValueId> = weights.iter().map(|w| t.leaf(w.clone())).collect();
+    let seq = tokens.len();
+    let mut hidden = t.embed_gather(wids[0], tokens, a.vocab, a.n_embd);
+    for li in 0..a.n_layers {
+        let base = 1 + 7 * li;
+        let an = t.leaf(a.attn_norms[li].clone());
+        let xn = t.rmsnorm(hidden, an, seq, a.n_embd, a.eps);
+        accumulate(&t, xn, seq, a.n_embd, &mut c.attn_in[li]);
+        let attn = attention(
+            &mut t,
+            xn,
+            wids[base],
+            wids[base + 1],
+            wids[base + 2],
+            wids[base + 3],
+            seq,
+            a.n_embd,
+            a.n_head,
+            a.n_head_kv,
+            a.head_dim,
+            a.theta,
+        );
+        hidden = t.add(hidden, attn);
+        let fnw = t.leaf(a.ffn_norms[li].clone());
+        let hn = t.rmsnorm(hidden, fnw, seq, a.n_embd, a.eps);
+        accumulate(&t, hn, seq, a.n_embd, &mut c.ffn_in[li]);
+        let g = t.dense_matmul(hn, wids[base + 4], seq, a.ff, a.n_embd);
+        let u = t.dense_matmul(hn, wids[base + 5], seq, a.ff, a.n_embd);
+        let ga = t.silu(g);
+        let gated = t.mul(ga, u);
+        accumulate(&t, gated, seq, a.ff, &mut c.down_in[li]);
+        let down = t.dense_matmul(gated, wids[base + 6], seq, a.n_embd, a.ff);
+        hidden = t.add(hidden, down);
+    }
+    c.rows += seq;
+}
+
+/// AWQ's salience scale: `s_j = (rms_j / geomean(rms))^α`, normalised by the geometric mean so the
+/// fold neither inflates nor shrinks the matrix overall (α=0 ⇒ all ones ⇒ exactly today's fitter).
+pub fn smooth_scales(acc: &[f64], rows: usize, alpha: f64) -> Vec<f32> {
+    let rms: Vec<f64> = acc
+        .iter()
+        .map(|&s| (s / rows as f64).sqrt().max(1e-8))
+        .collect();
+    let gm = (rms.iter().map(|r| r.ln()).sum::<f64>() / rms.len() as f64).exp();
+    rms.iter().map(|&r| (r / gm).powf(alpha) as f32).collect()
+}
+
+/// Multiply every column `j` of a row-major `[rows, cols]` matrix by `s[j]` — the weight half of
+/// the fold.
+pub fn scale_cols(w: &mut [f32], cols: usize, s: &[f32]) {
+    for row in w.chunks_mut(cols) {
+        for (v, &sj) in row.iter_mut().zip(s) {
+            *v *= sj;
+        }
+    }
+}
+
+/// Divide every row `r` by `s[r]` — the norm half of the fold, applied to the *preceding* norm so
+/// the product with [`scale_cols`] is the identity.
+pub fn divide_rows(w: &mut [f32], cols: usize, s: &[f32]) {
+    for (r, row) in w.chunks_mut(cols).enumerate() {
+        for v in row {
+            *v /= s[r];
+        }
+    }
+}
+
+/// Apply the salience fold. Returns the rebalanced weights plus the `Arch` whose fp norms absorb
+/// the inverse — together an exact reparameterisation of the same function.
+pub fn fold(
+    fp: &[Vec<f32>],
+    shapes: &[(usize, usize)],
+    a: &Arch,
+    c: &Calib,
+    alpha: f64,
+) -> (Vec<Vec<f32>>, Arch) {
+    let mut w = fp.to_vec();
+    let mut arch = a.clone();
+    for li in 0..a.n_layers {
+        let base = 1 + 7 * li;
+
+        // q, k, v — inverse into attn_norm.
+        let sa = smooth_scales(&c.attn_in[li], c.rows, alpha);
+        for k in 0..3 {
+            scale_cols(&mut w[base + k], shapes[base + k].1, &sa);
+        }
+        for (n, &s) in arch.attn_norms[li].iter_mut().zip(&sa) {
+            *n /= s;
+        }
+
+        // gate, up — inverse into ffn_norm.
+        let sf = smooth_scales(&c.ffn_in[li], c.rows, alpha);
+        for k in 4..6 {
+            scale_cols(&mut w[base + k], shapes[base + k].1, &sf);
+        }
+        for (n, &s) in arch.ffn_norms[li].iter_mut().zip(&sf) {
+            *n /= s;
+        }
+
+        // down — inverse into up's output rows (`gated = silu(gate) ⊙ up` is linear in up).
+        let sd = smooth_scales(&c.down_in[li], c.rows, alpha);
+        scale_cols(&mut w[base + 6], shapes[base + 6].1, &sd);
+        divide_rows(&mut w[base + 5], shapes[base + 5].1, &sd);
+    }
+    (w, arch)
+}

--- a/crates/tritium-nn/src/lib.rs
+++ b/crates/tritium-nn/src/lib.rs
@@ -13,6 +13,7 @@
 //! No `unsafe` here — the numerics are plain Rust; the backend owns the SIMD/GPU.
 #![forbid(unsafe_code)]
 
+pub mod calibrate;
 mod config;
 mod error;
 mod evaluation;

--- a/crates/tritium-nn/src/model/hf.rs
+++ b/crates/tritium-nn/src/model/hf.rs
@@ -307,7 +307,7 @@ pub(crate) enum NameSchema {
 
 impl NameSchema {
     /// Top-level (non-layer) slot name.
-    pub(super) fn top(self, slot: &str) -> &'static str {
+    pub(crate) fn top(self, slot: &str) -> &'static str {
         match (self, slot) {
             (NameSchema::Hf, "token_embd") => "model.embed_tokens.weight",
             (NameSchema::Hf, "output_norm") => "model.norm.weight",
@@ -320,7 +320,7 @@ impl NameSchema {
     }
 
     /// Per-layer slot name.
-    pub(super) fn layer(self, i: usize, slot: &str) -> String {
+    pub(crate) fn layer(self, i: usize, slot: &str) -> String {
         let s = match (self, slot) {
             (NameSchema::Hf, _) => {
                 return format!(

--- a/crates/tritium-nn/src/model/mod.rs
+++ b/crates/tritium-nn/src/model/mod.rs
@@ -26,6 +26,11 @@ mod weights;
 
 #[cfg(feature = "tokenizer")]
 pub use bpe_tokenizer::GgufBpeTokenizer;
+// The tensor-name schema the SALT loader resolves tensors by. Crate-visible so `calibrate` can
+// label a converted artifact with the same spellings, instead of a second copy of the convention
+// living in whichever crate writes the file. Deliberately not feature-gated: naming has nothing to
+// do with tokenizers, and it was briefly captured by the `tokenizer` cfg above.
+pub(crate) use hf::NameSchema;
 #[cfg(feature = "tokenizer")]
 pub use hf_json_tokenizer::HfJsonTokenizer;
 pub use qwen35::{

--- a/crates/tritium-nn/tests/common/mod.rs
+++ b/crates/tritium-nn/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, unreachable_pub)]
+#![allow(dead_code, unreachable_pub, unused_imports)]
 //! Shared differentiable-model helpers for the SALT-distillation tests (the ModelRunner-validated
 //! tape forward, ppl, and weight extraction). Kept in `tests/common` so multiple test binaries
 //! reuse the one validated forward instead of copying it.
@@ -9,118 +9,14 @@ use tritium_train::nn::attention;
 use tritium_train::ops::ste::{self, RotationPolicy};
 use tritium_train::tape::ValueId;
 
-/// Dims + fp 1D norms for the tape forward (the parts held fp, not quantized/trained).
-pub struct Arch {
-    pub attn_norms: Vec<Vec<f32>>,
-    pub ffn_norms: Vec<Vec<f32>>,
-    pub out_norm: Vec<f32>,
-    pub n_embd: usize,
-    pub n_head: usize,
-    pub n_head_kv: usize,
-    pub head_dim: usize,
-    pub ff: usize,
-    pub vocab: usize,
-    pub eps: f32,
-    pub theta: f32,
-    pub n_layers: usize,
-}
-
-pub fn dense(p: &Projection) -> (Vec<f32>, usize, usize) {
-    match p {
-        Projection::Dense(d) => (d.weights.clone(), d.n_out, d.k_in),
-        Projection::Salt(_)
-        | Projection::HostSaltV2(_)
-        | Projection::Ternary(_)
-        | Projection::Q2(_) => {
-            panic!("from_hf builds Dense projections")
-        }
-        #[cfg(feature = "cuda")]
-        Projection::SaltV2(_) => panic!("from_hf builds Dense projections"),
-    }
-}
-
-/// Extract the tape `Arch`, the flat fp weights (index 0 = tied token_embd, then per layer
-/// q,k,v,o,gate,up,down), and their `(n_out, k_in)` shapes from a loaded runner.
-pub fn extract(runner: &ModelRunner) -> (Arch, Vec<Vec<f32>>, Vec<(usize, usize)>) {
-    let cfg = &runner.config;
-    let w = &runner.weights;
-    assert!(w.lm_head.is_none(), "assumes tied lm-head");
-    let arch = Arch {
-        attn_norms: w.layers.iter().map(|b| b.attn_norm.clone()).collect(),
-        ffn_norms: w.layers.iter().map(|b| b.ffn_norm.clone()).collect(),
-        out_norm: w.output_norm.clone(),
-        n_embd: cfg.n_embd as usize,
-        n_head: cfg.n_head as usize,
-        n_head_kv: cfg.n_head_kv as usize,
-        head_dim: cfg.head_dim() as usize,
-        ff: match &w.layers[0].mlp {
-            Mlp::SwiGlu(m) => dense(&m.gate).1,
-            Mlp::Relu2(_) => panic!("SwiGLU"),
-        },
-        vocab: w.vocab,
-        eps: cfg.rms_eps,
-        theta: cfg.rope_theta,
-        n_layers: w.layers.len(),
-    };
-    let mut fp: Vec<Vec<f32>> = vec![
-        w.token_embd
-            .as_dense()
-            .expect("training reference requires dense token embedding")
-            .to_vec(),
-    ];
-    let mut shapes: Vec<(usize, usize)> = vec![(w.vocab, arch.n_embd)];
-    for b in w.layers.iter() {
-        let (gate, up, down) = match &b.mlp {
-            Mlp::SwiGlu(m) => (&m.gate, &m.up, &m.down),
-            Mlp::Relu2(_) => unreachable!(),
-        };
-        for p in [&b.q_proj, &b.k_proj, &b.v_proj, &b.o_proj, gate, up, down] {
-            let (wv, n, k) = dense(p);
-            fp.push(wv);
-            shapes.push((n, k));
-        }
-    }
-    (arch, fp, shapes)
-}
-
-/// The whole-model forward on the tape (validated bit-exact vs `ModelRunner` in
-/// `tape_model_conformance`): embed_gather → N GQA blocks → SwiGLU → tied head. `wids[0]` is the
-/// tied embed/head; then per layer `q,k,v,o,gate,up,down`. Returns `[tokens.len(), vocab]` logits.
-pub fn forward(t: &mut Tape, wids: &[ValueId], a: &Arch, tokens: &[u32]) -> ValueId {
-    let seq = tokens.len();
-    let mut hidden = t.embed_gather(wids[0], tokens, a.vocab, a.n_embd);
-    for li in 0..a.n_layers {
-        let base = 1 + 7 * li;
-        let an = t.leaf(a.attn_norms[li].clone());
-        let xn = t.rmsnorm(hidden, an, seq, a.n_embd, a.eps);
-        let attn = attention(
-            t,
-            xn,
-            wids[base],
-            wids[base + 1],
-            wids[base + 2],
-            wids[base + 3],
-            seq,
-            a.n_embd,
-            a.n_head,
-            a.n_head_kv,
-            a.head_dim,
-            a.theta,
-        );
-        hidden = t.add(hidden, attn);
-        let fnw = t.leaf(a.ffn_norms[li].clone());
-        let hn = t.rmsnorm(hidden, fnw, seq, a.n_embd, a.eps);
-        let g = t.dense_matmul(hn, wids[base + 4], seq, a.ff, a.n_embd);
-        let u = t.dense_matmul(hn, wids[base + 5], seq, a.ff, a.n_embd);
-        let ga = t.silu(g);
-        let gated = t.mul(ga, u);
-        let down = t.dense_matmul(gated, wids[base + 6], seq, a.n_embd, a.ff);
-        hidden = t.add(hidden, down);
-    }
-    let onw = t.leaf(a.out_norm.clone());
-    let fnorm = t.rmsnorm(hidden, onw, seq, a.n_embd, a.eps);
-    t.dense_matmul(fnorm, wids[0], seq, a.vocab, a.n_embd) // tied head
-}
+// Calibration and the salience fold were promoted into the library
+// (`tritium_nn::calibrate`) so the CLI can reach them. Re-exported here rather than kept as a
+// second copy: a duplicated fold is exactly the train/eval quantizer mismatch that already forced
+// one retraction in this repo.
+pub use tritium_nn::calibrate::{
+    Arch, Calib, accumulate, calibrate, dense, divide_rows, extract, fold, forward, scale_cols,
+    smooth_scales,
+};
 
 /// The device mirror of [`forward`] on the GPU [`DeviceTape`](tritium_cuda::train::DeviceTape)
 /// (plan 0043 P2.5): assembles the whole model on-device using `weights` as the 2D-weight leaves
@@ -484,46 +380,6 @@ pub const ITERS: usize = 5;
 // channel by how much the activations actually use it. For weight-only quantization that objective
 // has an exact, inference-free implementation: scale weight column `j` by `s_j` from calibration
 // and push `1/s_j` into a tensor that is already free.
-/// Per-input-channel second moments for the projections whose scale is foldable.
-pub struct Calib {
-    pub attn_in: Vec<Vec<f64>>, // [layer][n_embd] — input to q, k, v
-    pub ffn_in: Vec<Vec<f64>>,  // [layer][n_embd] — input to gate, up
-    pub down_in: Vec<Vec<f64>>, // [layer][ff]     — input to down
-    pub rows: usize,
-}
-
-impl Calib {
-    pub fn new(a: &Arch) -> Self {
-        Self {
-            attn_in: vec![vec![0.0; a.n_embd]; a.n_layers],
-            ffn_in: vec![vec![0.0; a.n_embd]; a.n_layers],
-            down_in: vec![vec![0.0; a.ff]; a.n_layers],
-            rows: 0,
-        }
-    }
-}
-
-/// Accumulate `Σ x²` per column of a `[seq, cols]` tape value.
-pub fn accumulate(t: &Tape, id: ValueId, seq: usize, cols: usize, acc: &mut [f64]) {
-    let v = t.value(id);
-    for r in 0..seq {
-        for (c, a) in acc.iter_mut().enumerate() {
-            let x = f64::from(v[r * cols + c]);
-            *a += x * x;
-        }
-    }
-}
-
-/// Full input **Gram** `Σ x xᵀ` for one tap point — the curvature GPTQ actually needs.
-///
-/// [`Calib`] keeps only the diagonal (`Σ x²` per channel), which is all the AWQ-style salience fold
-/// requires. Sequential error compensation needs the OFF-DIAGONAL terms too: when column `j` is
-/// rounded, the error it induces is pushed onto the not-yet-quantized columns through `H⁻¹`, and
-/// `H = Σ x xᵀ` is what says how those columns covary.
-///
-/// Stored as a dense lower-triangle-symmetric `k×k` in f64. At `k = 1536` that is 18.9 MB per tap
-/// point, which is why this is a separate opt-in structure rather than something [`Calib`] always
-/// carries.
 pub struct Gram {
     pub k: usize,
     /// Row-major `k×k`, symmetric.
@@ -762,130 +618,6 @@ pub fn damped_inverse(h: &[f64], k: usize, damp: f64) -> Option<Vec<f64>> {
         }
     }
     Some(out)
-}
-
-/// One calibration forward. Mirrors `common::forward` exactly, tapping the three foldable inputs.
-pub fn calibrate(weights: &[Vec<f32>], a: &Arch, tokens: &[u32], c: &mut Calib) {
-    let mut t = Tape::new();
-    let wids: Vec<ValueId> = weights.iter().map(|w| t.leaf(w.clone())).collect();
-    let seq = tokens.len();
-    let mut hidden = t.embed_gather(wids[0], tokens, a.vocab, a.n_embd);
-    for li in 0..a.n_layers {
-        let base = 1 + 7 * li;
-        let an = t.leaf(a.attn_norms[li].clone());
-        let xn = t.rmsnorm(hidden, an, seq, a.n_embd, a.eps);
-        accumulate(&t, xn, seq, a.n_embd, &mut c.attn_in[li]);
-        let attn = attention(
-            &mut t,
-            xn,
-            wids[base],
-            wids[base + 1],
-            wids[base + 2],
-            wids[base + 3],
-            seq,
-            a.n_embd,
-            a.n_head,
-            a.n_head_kv,
-            a.head_dim,
-            a.theta,
-        );
-        hidden = t.add(hidden, attn);
-        let fnw = t.leaf(a.ffn_norms[li].clone());
-        let hn = t.rmsnorm(hidden, fnw, seq, a.n_embd, a.eps);
-        accumulate(&t, hn, seq, a.n_embd, &mut c.ffn_in[li]);
-        let g = t.dense_matmul(hn, wids[base + 4], seq, a.ff, a.n_embd);
-        let u = t.dense_matmul(hn, wids[base + 5], seq, a.ff, a.n_embd);
-        let ga = t.silu(g);
-        let gated = t.mul(ga, u);
-        accumulate(&t, gated, seq, a.ff, &mut c.down_in[li]);
-        let down = t.dense_matmul(gated, wids[base + 6], seq, a.n_embd, a.ff);
-        hidden = t.add(hidden, down);
-    }
-    c.rows += seq;
-}
-
-/// AWQ's salience scale: `s_j = (rms_j / geomean(rms))^α`, normalised by the geometric mean so the
-/// fold neither inflates nor shrinks the matrix overall (α=0 ⇒ all ones ⇒ exactly today's fitter).
-pub fn smooth_scales(acc: &[f64], rows: usize, alpha: f64) -> Vec<f32> {
-    let rms: Vec<f64> = acc
-        .iter()
-        .map(|&s| (s / rows as f64).sqrt().max(1e-8))
-        .collect();
-    let gm = (rms.iter().map(|r| r.ln()).sum::<f64>() / rms.len() as f64).exp();
-    rms.iter().map(|&r| (r / gm).powf(alpha) as f32).collect()
-}
-
-pub fn scale_cols(w: &mut [f32], cols: usize, s: &[f32]) {
-    for row in w.chunks_mut(cols) {
-        for (v, &sj) in row.iter_mut().zip(s) {
-            *v *= sj;
-        }
-    }
-}
-
-pub fn divide_rows(w: &mut [f32], cols: usize, s: &[f32]) {
-    for (r, row) in w.chunks_mut(cols).enumerate() {
-        for v in row {
-            *v /= s[r];
-        }
-    }
-}
-
-pub fn clone_arch(a: &Arch) -> Arch {
-    Arch {
-        attn_norms: a.attn_norms.clone(),
-        ffn_norms: a.ffn_norms.clone(),
-        out_norm: a.out_norm.clone(),
-        n_embd: a.n_embd,
-        n_head: a.n_head,
-        n_head_kv: a.n_head_kv,
-        head_dim: a.head_dim,
-        ff: a.ff,
-        vocab: a.vocab,
-        eps: a.eps,
-        theta: a.theta,
-        n_layers: a.n_layers,
-    }
-}
-
-/// Apply the salience fold. Returns the rebalanced weights plus the `Arch` whose fp norms absorb
-/// the inverse — together an exact reparameterisation of the same function.
-pub fn fold(
-    fp: &[Vec<f32>],
-    shapes: &[(usize, usize)],
-    a: &Arch,
-    c: &Calib,
-    alpha: f64,
-) -> (Vec<Vec<f32>>, Arch) {
-    let mut w = fp.to_vec();
-    let mut arch = clone_arch(a);
-    for li in 0..a.n_layers {
-        let base = 1 + 7 * li;
-
-        // q, k, v — inverse into attn_norm.
-        let sa = smooth_scales(&c.attn_in[li], c.rows, alpha);
-        for k in 0..3 {
-            scale_cols(&mut w[base + k], shapes[base + k].1, &sa);
-        }
-        for (n, &s) in arch.attn_norms[li].iter_mut().zip(&sa) {
-            *n /= s;
-        }
-
-        // gate, up — inverse into ffn_norm.
-        let sf = smooth_scales(&c.ffn_in[li], c.rows, alpha);
-        for k in 4..6 {
-            scale_cols(&mut w[base + k], shapes[base + k].1, &sf);
-        }
-        for (n, &s) in arch.ffn_norms[li].iter_mut().zip(&sf) {
-            *n /= s;
-        }
-
-        // down — inverse into up's output rows (`gated = silu(gate) ⊙ up` is linear in up).
-        let sd = smooth_scales(&c.down_in[li], c.rows, alpha);
-        scale_cols(&mut w[base + 6], shapes[base + 6].1, &sd);
-        divide_rows(&mut w[base + 5], shapes[base + 5].1, &sd);
-    }
-    (w, arch)
 }
 
 pub fn quantize(

--- a/crates/tritium-nn/tests/convert_anchor_diagnostic.rs
+++ b/crates/tritium-nn/tests/convert_anchor_diagnostic.rs
@@ -1,0 +1,148 @@
+//! **Why does `tritium convert --fold-alpha 0` score 19.263 when the ladder anchor is 15.268?**
+//!
+//! `convert_roundtrip` compares a converted artifact against a number the research harness
+//! produced. Those two numbers travel through *different machinery* in two independent ways, and
+//! the failure does not say which one moved:
+//!
+//! | | anchor (15.268) | `convert_roundtrip` (19.263) |
+//! |---|---|---|
+//! | weights scored | the fitter's dense f32 reconstruction | TQ2_0-packed planes, f16 block scales |
+//! | forward | `common::perplexity_windowed` (tape, whole window at once) | `ModelRunner` teacher-forced, token by token |
+//! | eval tokens | all 32,768 | the first 8,192 |
+//!
+//! Any of the three could account for a 26% gap, so this measures a 2×2 on **one fixed slice**:
+//!
+//! - **A** fp weights, tape forward → the fp reference for this evaluator
+//! - **B** fp weights, `ModelRunner` forward → A vs B isolates the **evaluator**
+//! - **C** ladder fit, tape forward → reproduces the anchor's method; C vs the 15.268 anchor
+//!   isolates the **eval slice**
+//! - **D** the converted artifact, `ModelRunner` forward → C vs D isolates **fit vs artifact**,
+//!   which is the only cell where a bug in `tritium convert` could live
+//!
+//! Ratios are what matter. Comparing D against an absolute number measured on a different slice
+//! with a different forward was the mistake that produced the confusing failure in the first place.
+//!
+//! ```text
+//! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-360m \
+//! TRITIUM_CORPUS=$HOME/.cache/tritium-corpora/wikitext2_400k_32k.json \
+//! TRITIUM_CONVERTED_DIR=/tmp/tritium-convert-rt-3799551/unfolded \
+//!   cargo test -p tritium-nn --release --test convert_anchor_diagnostic -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use std::path::PathBuf;
+
+use common::{extract, perplexity_windowed};
+use tritium_nn::{ModelRunner, teacher_forced_perplexity_windows};
+use tritium_train::ops::ste::{self, RotationPolicy};
+
+const WINDOW: usize = 512;
+const TOKENS: usize = 8192;
+const PLANES: usize = 4;
+const GROUP: usize = 256;
+const GRID: usize = 16;
+
+/// The published anchor this diagnostic exists to explain: SmolLM2-360M, ladder T=4, g256, no
+/// fold, no rotation, measured by the research harness on the full eval split.
+const ANCHOR: f64 = 15.268;
+/// The fp master under the same harness and split.
+const ANCHOR_FP: f64 = 14.909;
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(std::env::var(key).unwrap_or_else(|_| panic!("set {key}")))
+}
+
+fn eval_tokens() -> Vec<u32> {
+    let bytes = std::fs::read(env_path("TRITIUM_CORPUS")).expect("read corpus");
+    let value: serde_json::Value = serde_json::from_slice(&bytes).expect("parse corpus");
+    value["eval_ids"]
+        .as_array()
+        .expect("eval_ids")
+        .iter()
+        .map(|v| v.as_u64().expect("token id") as u32)
+        .take(TOKENS)
+        .collect()
+}
+
+fn runner_ppl(load: impl FnOnce() -> ModelRunner, tokens: &[u32]) -> f64 {
+    let mut runner = load();
+    teacher_forced_perplexity_windows(&mut runner, tokens, WINDOW)
+        .expect("score")
+        .perplexity
+}
+
+#[test]
+#[ignore = "four full evaluations of a 360M model on CPU"]
+fn locate_the_gap_between_the_artifact_and_the_anchor() {
+    let model = env_path("TRITIUM_MODEL_DIR");
+    let converted = env_path("TRITIUM_CONVERTED_DIR");
+    let tokens = eval_tokens();
+    assert_eq!(tokens.len(), TOKENS);
+
+    let runner = ModelRunner::from_hf(&model, Box::new(tritium_cpu::CpuBackend::new()))
+        .expect("load fp master");
+    let (arch, fp, shapes) = extract(&runner);
+    drop(runner);
+
+    let a = perplexity_windowed(&fp, &arch, &tokens, WINDOW);
+    println!("A  fp        / tape    : {a:.3}");
+
+    let b = runner_ppl(
+        || {
+            ModelRunner::from_hf(&model, Box::new(tritium_cpu::CpuBackend::new()))
+                .expect("load fp master")
+        },
+        &tokens,
+    );
+    println!("B  fp        / runner  : {b:.3}");
+
+    // The anchor's own recipe, dense: no fold, no rotation, geometric ladder at T=4/g256.
+    let fitted: Vec<Vec<f32>> = fp
+        .iter()
+        .zip(&shapes)
+        .map(|(w, &(n, k))| {
+            ste::salt_quantize_forward_grouped_geometric(
+                w,
+                n,
+                k,
+                PLANES,
+                GROUP,
+                GRID,
+                RotationPolicy::Never,
+            )
+        })
+        .collect();
+    let c = perplexity_windowed(&fitted, &arch, &tokens, WINDOW);
+    println!("C  ladder    / tape    : {c:.3}");
+
+    let d = runner_ppl(
+        || {
+            ModelRunner::from_salt(
+                &converted,
+                &converted.join("model.tslb"),
+                Box::new(tritium_cpu::CpuBackend::new()),
+            )
+            .expect("load converted artifact")
+        },
+        &tokens,
+    );
+    println!("D  artifact  / runner  : {d:.3}");
+
+    println!("\n--- attribution ---");
+    println!("evaluator  (B/A)           : {:.4}x", b / a);
+    println!("slice      (C vs {ANCHOR:.3})    : {:.4}x", c / ANCHOR);
+    println!("fit->artifact (D/C)        : {:.4}x", d / c);
+    println!(
+        "degradation vs fp, tape    : {:.4}x  (anchor: {:.4}x)",
+        c / a,
+        ANCHOR / ANCHOR_FP
+    );
+    println!("degradation vs fp, runner  : {:.4}x", d / b);
+    println!(
+        "\nThe quantity that must match the anchor is the RATIO to fp under the SAME evaluator: \
+         D/B = {:.4}x versus the anchor's {:.4}x.",
+        d / b,
+        ANCHOR / ANCHOR_FP
+    );
+}

--- a/crates/tritium-nn/tests/ladder_f16_scale_underflow.rs
+++ b/crates/tritium-nn/tests/ladder_f16_scale_underflow.rs
@@ -1,0 +1,225 @@
+//! **Does the TQ2_0 f16 block scale destroy the ladder's fine planes on a real model?**
+//!
+//! `convert_anchor_diagnostic` localised a 2.76% perplexity gap to exactly one step: the fitter's
+//! dense reconstruction versus the packed artifact (`D/C = 1.0276`). The evaluator was ruled out
+//! (fp scores 18.240 through both the tape and `ModelRunner`), and the fit itself reproduces the
+//! published anchor.
+//!
+//! The ladder assigns plane `p` the scale `s₀·3^-p`. A SALT bundle stores each plane as TQ2_0,
+//! which carries **one f16 scale per 256-trit block**. f16's smallest *normal* value is 6.104e-5;
+//! below that it degrades into subnormals with progressively fewer significand bits, and it flushes
+//! to zero at 5.96e-8. At `T = 4` the finest plane is `s₀/27`, so any group whose anchor is small
+//! enough loses that plane — silently, because a zero scale is a perfectly valid TQ2_0 block.
+//!
+//! `ladder_bundle_roundtrip` cannot see this: it fits synthetic uniform data, where every group's
+//! `s₀` is the same order of magnitude and `s₀/27` is nowhere near the f16 floor. A real model's
+//! per-group anchors span orders of magnitude.
+//!
+//! This measures the real distribution and the resulting reconstruction error, so the answer is
+//! data rather than argument.
+//!
+//! ```text
+//! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-360m \
+//!   cargo test -p tritium-nn --release --test ladder_f16_scale_underflow -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use std::path::PathBuf;
+
+use common::extract;
+use half::f16;
+use tritium_nn::ModelRunner;
+use tritium_train::ops::ste::{self, RotationPolicy};
+
+const PLANES: usize = 4;
+const GROUP: usize = 256;
+const GRID: usize = 16;
+
+/// Smallest positive **normal** f16. Below this, significand bits are lost one at a time.
+const F16_MIN_NORMAL: f64 = 6.103_515_625e-5;
+
+fn relative_frobenius(reference: &[f32], other: &[f32]) -> f64 {
+    let mut se = 0.0f64;
+    let mut sw = 0.0f64;
+    for (&a, &b) in reference.iter().zip(other) {
+        let d = f64::from(a) - f64::from(b);
+        se += d * d;
+        sw += f64::from(a) * f64::from(a);
+    }
+    if sw > 0.0 { (se / sw).sqrt() } else { 0.0 }
+}
+
+#[test]
+#[ignore = "needs a real fp master"]
+fn f16_block_scales_preserve_every_ladder_plane() {
+    let dir = PathBuf::from(
+        std::env::var("TRITIUM_MODEL_DIR").expect("set TRITIUM_MODEL_DIR to an fp model directory"),
+    );
+    let runner =
+        ModelRunner::from_hf(&dir, Box::new(tritium_cpu::CpuBackend::new())).expect("load fp");
+    let (_arch, fp, shapes) = extract(&runner);
+    drop(runner);
+
+    let mut anchors: Vec<f64> = Vec::new();
+    let mut subnormal = [0usize; PLANES];
+    let mut flushed = [0usize; PLANES];
+    let mut total_groups = 0usize;
+
+    // Reconstruction error introduced purely by rounding each plane's scale to f16, isolated from
+    // every other step: same trits, same fit, only the scale representation differs.
+    let mut worst_tensor = (String::new(), 0.0f64);
+    let mut se_total = 0.0f64;
+    let mut sw_total = 0.0f64;
+
+    for (i, (w, &(n, k))) in fp.iter().zip(&shapes).enumerate() {
+        let fits = ste::geometric_ladder_fit(w, n, k, PLANES, GROUP, GRID, RotationPolicy::Never);
+        let groups_per_row = k.div_ceil(GROUP);
+
+        // Dense reconstruction at f32 scales (what the fitter intends) and at f16 scales (what a
+        // TQ2_0 block can actually hold).
+        let mut exact = vec![0.0f32; n * k];
+        let mut rounded = vec![0.0f32; n * k];
+        for r in 0..n {
+            for g in 0..groups_per_row {
+                let (s0, planes) = &fits[r * groups_per_row + g];
+                total_groups += 1;
+                anchors.push(f64::from(*s0));
+                let mut scale = f64::from(*s0);
+                for (p, digits) in planes.iter().enumerate().take(PLANES) {
+                    let as_f16 = f16::from_f64(scale);
+                    if scale < F16_MIN_NORMAL {
+                        subnormal[p] += 1;
+                    }
+                    if as_f16 == f16::ZERO && scale > 0.0 {
+                        flushed[p] += 1;
+                    }
+                    let start = g * GROUP;
+                    let len = GROUP.min(k - start);
+                    for (j, &d) in digits.iter().enumerate().take(len) {
+                        let idx = r * k + start + j;
+                        exact[idx] += (scale * f64::from(d)) as f32;
+                        rounded[idx] += f32::from(as_f16) * f32::from(d);
+                    }
+                    scale /= 3.0;
+                }
+            }
+        }
+
+        for (&a, &b) in exact.iter().zip(&rounded) {
+            let d = f64::from(a) - f64::from(b);
+            se_total += d * d;
+            sw_total += f64::from(a) * f64::from(a);
+        }
+        let rel = relative_frobenius(&exact, &rounded);
+        if rel > worst_tensor.1 {
+            worst_tensor = (format!("weights[{i}] {n}x{k}"), rel);
+        }
+    }
+
+    anchors.sort_by(|a, b| a.partial_cmp(b).expect("finite anchors"));
+    let pct = |q: f64| anchors[((anchors.len() - 1) as f64 * q) as usize];
+    println!("groups: {total_groups}");
+    println!(
+        "s0 percentiles: min {:.3e}  p1 {:.3e}  p50 {:.3e}  max {:.3e}",
+        anchors[0],
+        pct(0.01),
+        pct(0.50),
+        anchors[anchors.len() - 1]
+    );
+    println!("f16 min normal: {F16_MIN_NORMAL:.3e}");
+    for p in 0..PLANES {
+        println!(
+            "plane {p} (s0/3^{p}): {:>9} subnormal ({:.3}%), {:>9} flushed to zero ({:.3}%)",
+            subnormal[p],
+            100.0 * subnormal[p] as f64 / total_groups as f64,
+            flushed[p],
+            100.0 * flushed[p] as f64 / total_groups as f64,
+        );
+    }
+    let whole = (se_total / sw_total).sqrt();
+    println!("\nrelative Frobenius error from f16 SCALE ROUNDING ALONE: {whole:.6}");
+    println!("worst tensor: {} at {:.6}", worst_tensor.0, worst_tensor.1);
+    println!(
+        "for scale: the whole T=4 quantization itself costs ~0.025-0.038 relative error, and the \
+         measured fit->artifact perplexity gap is 2.76%."
+    );
+}
+
+/// **Do the artifact's decoded weights equal the fitter's reconstruction on a REAL model?**
+///
+/// `ladder_bundle_roundtrip` asks this on synthetic tensors up to 3x576. It passes, which proves
+/// the packer is right for those shapes and nothing more. The real model has a 49152x960 tied
+/// embedding, 320x960 kv projections, and 960 columns that split into three full 256-trit groups
+/// plus a 192-wide tail on *every* tensor.
+///
+/// This decodes the bundle `tritium convert` actually wrote and compares it against
+/// `salt_quantize_forward_grouped_geometric` — the same oracle the perplexity anchor was measured
+/// through. It separates two very different diagnoses for the measured 2.76% fit-to-artifact
+/// perplexity gap: bytes that decode to the wrong values, versus bytes that are right and a
+/// runtime that computes with them differently.
+#[test]
+#[ignore = "needs a real fp master and a converted artifact"]
+fn artifact_decodes_to_the_fit_on_a_real_model() {
+    use tritium_format::{read_salt_bundle, salt_rows_to_dense};
+    use tritium_nn::calibrate::weight_names;
+
+    let dir = PathBuf::from(std::env::var("TRITIUM_MODEL_DIR").expect("set TRITIUM_MODEL_DIR"));
+    let converted =
+        PathBuf::from(std::env::var("TRITIUM_CONVERTED_DIR").expect("set TRITIUM_CONVERTED_DIR"));
+
+    let runner =
+        ModelRunner::from_hf(&dir, Box::new(tritium_cpu::CpuBackend::new())).expect("load fp");
+    let (arch, fp, shapes) = extract(&runner);
+    drop(runner);
+    let names = weight_names(&arch);
+
+    let bytes = std::fs::read(converted.join("model.tslb")).expect("read bundle");
+    let tensors = read_salt_bundle(&bytes).expect("parse bundle");
+    println!("bundle carries {} tensors", tensors.len());
+
+    let mut worst = (String::new(), 0.0f64);
+    let mut se_total = 0.0f64;
+    let mut sw_total = 0.0f64;
+    let mut checked = 0usize;
+
+    for (i, (name, &(n, k))) in names.iter().zip(&shapes).enumerate() {
+        let Some(t) = tensors.iter().find(|t| &t.name == name) else {
+            panic!("bundle has no tensor `{name}`");
+        };
+        assert_eq!((t.rows, t.k), (n, k), "{name} shape");
+
+        let oracle = ste::salt_quantize_forward_grouped_geometric(
+            &fp[i],
+            n,
+            k,
+            PLANES,
+            GROUP,
+            GRID,
+            RotationPolicy::Never,
+        );
+        let decoded = salt_rows_to_dense(&t.salt_rows).expect("decode");
+        assert_eq!(decoded.len(), oracle.len(), "{name} length");
+
+        for (&a, &b) in oracle.iter().zip(&decoded) {
+            let d = f64::from(a) - f64::from(b);
+            se_total += d * d;
+            sw_total += f64::from(a) * f64::from(a);
+        }
+        let rel = relative_frobenius(&oracle, &decoded);
+        if rel > worst.1 {
+            worst = (format!("{name} [{n}x{k}]"), rel);
+        }
+        checked += 1;
+    }
+
+    let whole = (se_total / sw_total).sqrt();
+    println!("checked {checked} tensors");
+    println!("whole-model relative Frobenius error, artifact vs fitter: {whole:.6}");
+    println!("worst tensor: {} at {:.6}", worst.0, worst.1);
+    println!(
+        "f16 scale rounding alone accounts for 0.000271. Anything materially above that is a \
+         packing defect on real shapes; anything at that level means the bytes are correct and the \
+         2.76% perplexity gap lives in the runtime, not the artifact."
+    );
+}


### PR DESCRIPTION
Two commits: promote calibration + the fold into `tritium-nn`, then build `tritium convert` on top. ADR 0038 WS-3.

## The gap being closed

`tritium quantize` reads a bare safetensors file, so it cannot compute activation statistics and cannot run the AWQ-style salience fold. **Every published SALT number was measured with that fold**, which is why the CLI's artifacts have always been a different configuration from the research runs. Measured worth on SmolLM2-360M: **2.3× at T=2, 8.5% at T=3, 1.1% at T=4**.

The fold is model-aware, not a tensor op: it scales projection columns by a per-channel salience `s` and divides the **preceding norm** by the same `s`. Knowing which norm feeds which projection is a property of the layer graph. So `convert` loads a model, calibrates, folds, ladder-fits, and writes.

## The output has to be a directory — not a style choice

`ModelWeights::load_salt` says it outright (`hf.rs:161`): *"only 1D norms come from the fp master."* The bundle carries the 2-D matrices and the token table; the norms are read from safetensors in the model directory. Since the fold modifies **both**, a converter emitting only a `.tslb` beside the source model would produce an artifact that **loads cleanly and evaluates as a wrecked model** — weights carrying a fold whose other half is missing.

| file | contents |
|---|---|
| `config.json` | copied verbatim |
| `model.safetensors` | the fp 1-D norms, **after** the fold (244 KiB at 360M) |
| `model.tslb` | SALT bundle: embedding + every projection |
| `receipt.json` | recipe + byte cost + per-tensor fidelity |
| tokenizer assets | copied when present |

Same asymmetry that makes the **Hadamard rotation unrepresentable** — a rotated fit reconstructs `W·H` and the format has nowhere to record `H`. The fold escapes it *only* because its other half lands in a tensor the format already carries. Rotation stays off, and the receipt records `"rotation": "none"` so its absence is evidence rather than an omission.

## One spelling of every tensor name

`NameSchema` was `pub(crate)` with `pub(super)` methods, unreachable from the CLI — and hardcoding the HF spellings in a second crate is how a rename becomes an artifact that writes fine and resolves nothing. Widened to crate visibility, and `calibrate::{weight_names, norm_tensors}` sit beside `extract` with unit tests pinning both the layout and the exact strings.

## Verification

- **`convert` reloads its own output before reporting success.** Every failure mode here — a name the loader doesn't look up, a shape the bundle disagrees with, a norm under the wrong key — yields a *structurally valid* file that never resolves. Nothing short of a reload distinguishes that from a good run.
- **The norms half is confirmed directly.** At `--fold-alpha 0` the written norms are **byte-identical** to the source. At `0.75` the per-channel ratio spans 0.042–15.58 with a **geometric mean of exactly 1.000000** — precisely what `smooth_scales`' gm-normalisation guarantees. The norms carry exactly the salience and nothing else.
- The promoted bodies **diff byte-identically** against the committed originals except two derives; `tape_model_conformance` (bit-exact vs `ModelRunner`) now runs through the library copy and passes.
- 360M end to end in **78 s**: 225 tensors, 361.76M params, 377.5 MiB bundle.
- `cargo fmt --check` clean; `clippy -p tritium-cli -p tritium-nn --all-targets` clean; calibrate unit tests pass with the `tokenizer` feature **off** — the build that catches a `cfg` capture.

## Fidelity receipt, on by default

Per-tensor relative Frobenius error **decoded from the written artifact**, so f16 block-scale rounding is included rather than idealised away. At 135M/T=4 the spread is real signal: `k_proj` (192×576) worst at 8.4%, `down_proj` best at 1.8%.

It carries its own caveat, because the receipt is what a downstream consumer reads: **weight-space error is not a quality ranking across recipes.** At 135M/T=4, `alpha=0` → 0.0252 and `alpha=0.75` → **0.0380** — the fold is 51% *worse* by this metric while being better by perplexity, since it trades weight-space error for error where activations are small. This repo already recorded the same inversion for per-group plane allocation (12.4% lower weight SSE, 12% worse perplexity).

## Known gap → WS-4

Nothing in the CLI consumes a converted directory: `generate` is GGUF-only, `report` takes fp masters. The artifact is library-loadable (`ModelRunner::from_salt`) and CLI-unrunnable. That is now the binding constraint on the adoption spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4