### PR TITLE
feat(cli): run a converted model from the CLI (ADR 0038 WS-4) + measure the int8-activation tax

### DIFF
--- a/crates/tritium-cli/src/generate.rs
+++ b/crates/tritium-cli/src/generate.rs
@@ -1,19 +1,39 @@
-//! `tritium generate`: load a GGUF model and greedily decode tokens.
+//! `tritium generate`: load a model and greedily decode tokens.
 //!
-//! The subcommand is deterministic and offline-reproducible: input token IDs come
-//! from a JSON file (`--tokens`), generation is greedy, and the output is the list
-//! of newly generated token IDs printed one per line (plus a JSON array for easy
-//! machine consumption). The model is loaded through
-//! [`tritium_nn::ModelRunner`], which selects a backend via the runtime registry.
+//! The subcommand is deterministic and offline-reproducible: generation is greedy, and the output
+//! is the list of newly generated token IDs printed one per line (plus a JSON array for easy
+//! machine consumption). The model is loaded through [`tritium_nn::ModelRunner`], which selects a
+//! backend via the runtime registry.
 //!
-//! Like the rest of the CLI, every failure flows through [`anyhow::Result`]: a
-//! missing model, an unreadable token file, malformed JSON, or a model that is
-//! missing weights all yield a clean message and a non-zero exit — never a panic.
+//! # Two kinds of model, because a converter that produces nothing runnable is half a feature
+//!
+//! `--model` accepts either a `.gguf` file or a **directory written by `tritium convert`** (ADR
+//! 0038 WS-4). Until this existed, `convert` wrote an artifact that only the library could load:
+//! `generate` was GGUF-only and `report` takes fp masters, so the adoption spine stopped one step
+//! short of running anything.
+//!
+//! A converted directory is recognised by the presence of `model.tslb` beside `config.json`, and
+//! loaded with [`ModelRunner::from_salt`]. Dispatching on *content* rather than on the `--model`
+//! spelling means a mistyped path fails as "not a model" instead of being silently treated as the
+//! other kind.
+//!
+//! # Prompts
+//!
+//! `--tokens <file.json>` remains the reproducible path: exact ids in, exact ids out, no tokenizer
+//! in the loop. `--prompt "..."` is the ergonomic one, and it uses the **model's own** tokenizer —
+//! `tokenizer.json` from a converted directory (which `convert` copies for exactly this reason) or
+//! the BPE embedded in a GGUF. Ids are only meaningful relative to the vocabulary that produced
+//! them, so there is no default tokenizer to fall back on; if none is available, the command says
+//! so rather than emitting confident nonsense.
+//!
+//! Like the rest of the CLI, every failure flows through [`anyhow::Result`]: a missing model, an
+//! unreadable token file, malformed JSON, or a model that is missing weights all yield a clean
+//! message and a non-zero exit — never a panic.
 
 use std::path::Path;
 
-use anyhow::Context as _;
-use tritium_nn::ModelRunner;
+use anyhow::{Context as _, bail};
+use tritium_nn::{GgufBpeTokenizer, HfJsonTokenizer, ModelRunner, Tokenizer};
 
 /// Parse a JSON file of input token IDs.
 ///
@@ -70,7 +90,7 @@ pub(crate) fn render_output(tokens: &[u32]) -> String {
 /// caller maps this to a non-zero exit; nothing here panics on bad input.
 pub(crate) fn run(
     model_path: &Path,
-    tokens: &[u32],
+    prompt: &Prompt<'_>,
     max_new: usize,
     greedy: bool,
     eos: u32,
@@ -82,17 +102,97 @@ pub(crate) fn run(
         );
     }
 
-    let bytes = std::fs::read(model_path)
-        .with_context(|| format!("failed to read model `{}`", model_path.display()))?;
-    let mut runner = ModelRunner::load_cpu(&bytes)
-        .with_context(|| format!("failed to load model `{}`", model_path.display()))?;
+    let (mut runner, tokenizer) = load(model_path)?;
+
+    let tokens = match prompt {
+        Prompt::Ids(ids) => (*ids).to_vec(),
+        Prompt::Text(text) => {
+            let Some(tokenizer) = tokenizer.as_ref() else {
+                bail!(
+                    "--prompt needs a tokenizer, and `{}` does not carry one. A `tritium convert` \
+                     directory has tokenizer.json (copied from the source model); a GGUF must embed \
+                     its BPE. Use --tokens <ids.json> instead, or convert from a source snapshot \
+                     that includes tokenizer.json.",
+                    model_path.display()
+                );
+            };
+            tokenizer
+                .encode(text)
+                .map_err(|e| anyhow::anyhow!("tokenize prompt: {e}"))?
+        }
+    };
+    if tokens.is_empty() {
+        bail!("the prompt is empty — nothing to condition generation on");
+    }
 
     let generated = runner
-        .generate(tokens, max_new, eos)
+        .generate(&tokens, max_new, eos)
         .context("generation failed")?;
 
+    // Text out only when text went in: `--tokens` promises exact ids in, exact ids out, and a
+    // decoded string there would be a different contract than the reproducible path advertises.
+    if let (Prompt::Text(_), Some(tokenizer)) = (prompt, tokenizer.as_ref())
+        && let Ok(text) = tokenizer.decode(&generated)
+    {
+        println!("{text}");
+    }
     print!("{}", render_output(&generated));
     Ok(())
+}
+
+/// What to condition generation on.
+pub(crate) enum Prompt<'a> {
+    /// Exact token ids from `--tokens`. No tokenizer is consulted, so this path is reproducible
+    /// across tokenizer versions.
+    Ids(&'a [u32]),
+    /// Raw text from `--prompt`, tokenized with the model's own tokenizer.
+    Text(&'a str),
+}
+
+/// Load a model, plus its tokenizer when it carries one.
+///
+/// Dispatches on **content**: a directory holding `model.tslb` is a `tritium convert` output and
+/// loads through [`ModelRunner::from_salt`]; anything else is read as a GGUF file. A path that is
+/// neither fails as "not a model" rather than being silently misread as the other kind.
+fn load(model_path: &Path) -> anyhow::Result<(ModelRunner, Option<Box<dyn Tokenizer>>)> {
+    if model_path.is_dir() {
+        let bundle = model_path.join("model.tslb");
+        if !bundle.exists() {
+            bail!(
+                "`{}` is a directory but has no model.tslb, so it is not a `tritium convert` \
+                 output. Pass a converted directory or a .gguf file.",
+                model_path.display()
+            );
+        }
+        let runner = ModelRunner::from_salt(
+            model_path,
+            &bundle,
+            Box::new(tritium_cpu::CpuBackend::new()),
+        )
+        .with_context(|| format!("failed to load converted model `{}`", model_path.display()))?;
+
+        // `convert` copies these; a source snapshot without them still converts fine, so their
+        // absence is a missing capability rather than a broken model.
+        let tokenizer_json = model_path.join("tokenizer.json");
+        let tokenizer = if tokenizer_json.exists() {
+            HfJsonTokenizer::from_files(&tokenizer_json, &model_path.join("tokenizer_config.json"))
+                .ok()
+                .map(|t| Box::new(t) as Box<dyn Tokenizer>)
+        } else {
+            None
+        };
+        return Ok((runner, tokenizer));
+    }
+
+    let bytes = std::fs::read(model_path)
+        .with_context(|| format!("failed to read model `{}`", model_path.display()))?;
+    let runner = ModelRunner::load_cpu(&bytes)
+        .with_context(|| format!("failed to load model `{}`", model_path.display()))?;
+    let tokenizer = tritium_format::read_gguf(&bytes)
+        .ok()
+        .and_then(|f| GgufBpeTokenizer::from_gguf(&f).ok())
+        .map(|t| Box::new(t) as Box<dyn Tokenizer>);
+    Ok((runner, tokenizer))
 }
 
 #[cfg(test)]
@@ -152,7 +252,7 @@ mod tests {
     fn run_on_missing_model_errors_cleanly() {
         let err = run(
             Path::new("/nonexistent/model.gguf"),
-            &[1, 2, 3],
+            &Prompt::Ids(&[1, 2, 3]),
             4,
             true,
             128_001,
@@ -162,5 +262,17 @@ mod tests {
             format!("{err:#}").contains("failed to read model"),
             "{err:#}"
         );
+    }
+
+    /// A path that exists but is a directory without `model.tslb` must be rejected as "not a
+    /// converted model", not fall through to `std::fs::read` and surface a bare EISDIR.
+    #[test]
+    fn run_on_a_directory_without_a_bundle_names_the_missing_file() {
+        let dir = std::env::temp_dir().join(format!("tritium-gen-unit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let err = run(&dir, &Prompt::Ids(&[1, 2, 3]), 4, true, 128_001)
+            .expect_err("a directory with no bundle must error");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(format!("{err:#}").contains("model.tslb"), "{err:#}");
     }
 }

--- a/crates/tritium-cli/src/main.rs
+++ b/crates/tritium-cli/src/main.rs
@@ -109,12 +109,18 @@ enum Command {
     },
     /// Load a GGUF model and greedily generate tokens from a JSON file of input IDs.
     Generate {
-        /// Path to the `.gguf` model file.
+        /// A `.gguf` model file, or a directory written by `tritium convert`.
         #[arg(long)]
         model: PathBuf,
-        /// Path to a JSON file holding the input token IDs, e.g. `[1, 128000, 9906]`.
-        #[arg(long)]
-        tokens: PathBuf,
+        /// Path to a JSON file holding the input token IDs, e.g. `[1, 128000, 9906]`. The
+        /// reproducible path: no tokenizer is consulted, so the same ids always go in and out.
+        #[arg(long, conflicts_with = "prompt", required_unless_present = "prompt")]
+        tokens: Option<PathBuf>,
+        /// Text prompt, tokenized with the MODEL'S OWN tokenizer (`tokenizer.json` in a
+        /// `tritium convert` directory, or the BPE embedded in a GGUF). Token ids are only
+        /// meaningful relative to the vocabulary that produced them, so there is no fallback.
+        #[arg(long, conflicts_with = "tokens")]
+        prompt: Option<String>,
         /// Maximum number of new tokens to generate.
         #[arg(long, default_value_t = 16)]
         max_new: usize,
@@ -427,12 +433,19 @@ fn main() -> anyhow::Result<()> {
         Command::Generate {
             model,
             tokens,
+            prompt,
             max_new,
             greedy,
             eos,
         } => {
-            let ids = generate::read_token_file(&tokens)?;
-            generate::run(&model, &ids, max_new, greedy, eos)?;
+            // clap guarantees exactly one of the two is present.
+            let ids = tokens.map(|p| generate::read_token_file(&p)).transpose()?;
+            let source = match (&ids, &prompt) {
+                (Some(ids), _) => generate::Prompt::Ids(ids),
+                (None, Some(text)) => generate::Prompt::Text(text),
+                (None, None) => unreachable!("clap requires --tokens or --prompt"),
+            };
+            generate::run(&model, &source, max_new, greedy, eos)?;
         }
         Command::Repack { input, output, to } => repack::run(&input, &output, to)?,
         Command::Transport { transport: command } => transport::run(command)?,

--- a/crates/tritium-cli/tests/generate_converted_dir.rs
+++ b/crates/tritium-cli/tests/generate_converted_dir.rs
@@ -1,0 +1,159 @@
+//! **Can a converted model actually be run from the CLI?** (ADR 0038 WS-4)
+//!
+//! `tritium convert` writes a ternary model directory. Until WS-4 nothing in the CLI consumed one:
+//! `generate` was GGUF-only and `report` takes fp masters, so the adoption spine — acquire, convert,
+//! run — stopped one step short of running anything. The artifact was library-loadable and
+//! CLI-unrunnable, which is a converter that produces nothing a user can use.
+//!
+//! The cheap half of this file needs no model at all: the dispatch is on *content*, and its refusal
+//! messages are the part a user hits first when they point `--model` somewhere wrong.
+//!
+//! The end-to-end half is `#[ignore]`d and needs a real fp master:
+//!
+//! ```text
+//! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-135m \
+//!   cargo test -p tritium-cli --release --test generate_converted_dir -- --ignored --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn tritium_bin() -> PathBuf {
+    let mut p = std::env::current_exe().expect("test exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("tritium")
+}
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(tritium_bin())
+        .args(args)
+        .output()
+        .expect("run tritium")
+}
+
+/// A directory that is not a converted model must say so. Before the content dispatch existed this
+/// path went to `std::fs::read`, which fails with a bare EISDIR — true but useless.
+#[test]
+fn a_directory_without_a_bundle_is_refused_by_name() {
+    let dir = std::env::temp_dir().join(format!("tritium-gen-empty-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let out = run(&[
+        "generate",
+        "--model",
+        dir.to_str().unwrap(),
+        "--prompt",
+        "hello",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success(), "should have failed: {stderr}");
+    assert!(
+        stderr.contains("model.tslb"),
+        "the error should name what is missing, got: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `--tokens` and `--prompt` are different contracts — exact ids in/out versus tokenizer in the
+/// loop — so taking both would leave the reproducibility guarantee ambiguous.
+#[test]
+fn tokens_and_prompt_are_mutually_exclusive() {
+    let out = run(&[
+        "generate",
+        "--model",
+        "/nonexistent.gguf",
+        "--tokens",
+        "/nonexistent.json",
+        "--prompt",
+        "hello",
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("cannot be used with") || stderr.contains("conflict"),
+        "clap should reject both at once, got: {stderr}"
+    );
+}
+
+/// Neither one is also an error: there is nothing to condition generation on.
+#[test]
+fn one_of_tokens_or_prompt_is_required() {
+    let out = run(&["generate", "--model", "/nonexistent.gguf"]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(!out.status.success());
+    assert!(
+        stderr.contains("required") || stderr.contains("--prompt"),
+        "clap should require one of them, got: {stderr}"
+    );
+}
+
+fn convert(model: &Path, out: &Path) {
+    let _ = std::fs::remove_dir_all(out);
+    let status = Command::new(tritium_bin())
+        .args([
+            "convert",
+            "--model",
+            model.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+            "--planes",
+            "4",
+            "--group",
+            "256",
+            "--fold-alpha",
+            "0",
+        ])
+        .status()
+        .expect("run tritium convert");
+    assert!(status.success(), "convert failed");
+}
+
+/// The whole spine in one test: convert a real model, then generate from the directory with a text
+/// prompt. This is the claim WS-4 exists to make true.
+#[test]
+#[ignore = "needs a real fp master; converts a whole model"]
+fn convert_then_generate_from_the_directory() {
+    let model = PathBuf::from(
+        std::env::var("TRITIUM_MODEL_DIR").expect("set TRITIUM_MODEL_DIR to an fp model directory"),
+    );
+    let out = std::env::temp_dir().join(format!("tritium-gen-e2e-{}", std::process::id()));
+    convert(&model, &out);
+
+    let result = run(&[
+        "generate",
+        "--model",
+        out.to_str().unwrap(),
+        "--prompt",
+        "The capital of France is",
+        "--max-new",
+        "8",
+    ]);
+    let stdout = String::from_utf8_lossy(&result.stdout);
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    println!("--- stdout ---\n{stdout}");
+    assert!(result.status.success(), "generate failed: {stderr}");
+
+    // `render_output` always emits a JSON array line; ids prove the model ran, and the decoded text
+    // line above it proves the tokenizer round-tripped.
+    let ids_line = stdout
+        .lines()
+        .find(|l| l.starts_with('[') && l.ends_with(']'))
+        .unwrap_or_else(|| panic!("no JSON id array in output:\n{stdout}"));
+    let ids: Vec<u32> = serde_json::from_str(ids_line).expect("parse id array");
+    assert!(!ids.is_empty(), "generated nothing");
+    assert!(ids.len() <= 8, "respected --max-new, got {}", ids.len());
+
+    // Ids must be inside the model's vocabulary. A tokenizer/model mismatch would otherwise show up
+    // only as garbled text, which is easy to squint past.
+    let config: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out.join("config.json")).expect("read config"))
+            .expect("parse config");
+    let vocab = config["vocab_size"].as_u64().expect("vocab_size") as u32;
+    for id in &ids {
+        assert!(*id < vocab, "token id {id} outside vocab {vocab}");
+    }
+
+    let _ = std::fs::remove_dir_all(&out);
+}

--- a/crates/tritium-nn/tests/a8_activation_cost.rs
+++ b/crates/tritium-nn/tests/a8_activation_cost.rs
@@ -1,0 +1,175 @@
+//! **What do int8 activations cost, and does it depend on the plane count?**
+//!
+//! Every SALT perplexity this repo has published is *weight*-quantized only: the harnesses score
+//! `ste::salt_quantize_forward_grouped*` dense reconstructions through `Tape::dense_matmul`, which
+//! consumes fp32 activations. The shipping runtime does not — `SaltLinear::forward`
+//! (`crates/tritium-nn/src/layers/salt.rs:114`) calls `quantize_activation_int8` before every
+//! projection, and `Projection::Salt` declares `ProjectionActivationMode::A8` where
+//! `Projection::Dense` declares `F32`.
+//!
+//! `convert_anchor_diagnostic` measured that difference at **1.0276×** for T=4 on SmolLM2-360M,
+//! having first ruled out the evaluator (fp scores identically through both paths) and the packer
+//! (bytes decode to the fit at the f16 floor). So the fp-parity claim is a statement about weight
+//! quantization, and a user running the artifact pays more.
+//!
+//! One number is not a result. This measures the A8 cost **as a function of plane count**, which is
+//! the question that decides how it should be reported:
+//!
+//! - If the cost is roughly constant in `T`, it is an additive activation tax and can be quoted
+//!   once alongside any weight-quantization figure.
+//! - If it *grows* with `T`, then the high-`T` fp-parity numbers are the most overstated ones, and
+//!   the parity claim degrades exactly where it is currently strongest.
+//! - If it *shrinks* with `T`, more planes buy tolerance to int8 activations, which is itself an
+//!   argument for the ladder.
+//!
+//! Both arms per `T` use the same weights, slice and window; only the activation precision differs.
+//!
+//! ```text
+//! TRITIUM_MODEL_DIR=$HOME/.cache/tritium-models/smollm2-360m \
+//! TRITIUM_CORPUS=$HOME/.cache/tritium-corpora/wikitext2_400k_32k.json \
+//!   cargo test -p tritium-nn --release --test a8_activation_cost -- --ignored --nocapture
+//! ```
+
+mod common;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use common::{extract, perplexity_windowed};
+use tritium_nn::{ModelRunner, teacher_forced_perplexity_windows};
+use tritium_train::ops::ste::{self, RotationPolicy};
+
+const WINDOW: usize = 512;
+const TOKENS: usize = 8192;
+const GROUP: usize = 256;
+const GRID: usize = 16;
+/// `tritium convert` refuses fewer than 3 planes without rotation (323× fp at T=2 measured), so the
+/// shipping range is the range worth measuring.
+const PLANE_COUNTS: [usize; 2] = [3, 4];
+
+fn env_path(key: &str) -> PathBuf {
+    PathBuf::from(std::env::var(key).unwrap_or_else(|_| panic!("set {key}")))
+}
+
+fn tritium_bin() -> PathBuf {
+    let mut p = std::env::current_exe().expect("test exe");
+    p.pop();
+    if p.ends_with("deps") {
+        p.pop();
+    }
+    p.join("tritium")
+}
+
+fn eval_tokens() -> Vec<u32> {
+    let bytes = std::fs::read(env_path("TRITIUM_CORPUS")).expect("read corpus");
+    let value: serde_json::Value = serde_json::from_slice(&bytes).expect("parse corpus");
+    value["eval_ids"]
+        .as_array()
+        .expect("eval_ids")
+        .iter()
+        .map(|v| v.as_u64().expect("token id") as u32)
+        .take(TOKENS)
+        .collect()
+}
+
+#[test]
+#[ignore = "several full evaluations of a real model on CPU"]
+fn int8_activation_cost_across_plane_counts() {
+    let model = env_path("TRITIUM_MODEL_DIR");
+    let tokens = eval_tokens();
+    assert_eq!(tokens.len(), TOKENS);
+
+    let runner = ModelRunner::from_hf(&model, Box::new(tritium_cpu::CpuBackend::new()))
+        .expect("load fp master");
+    let (arch, fp, shapes) = extract(&runner);
+    drop(runner);
+
+    // fp reference under BOTH evaluators. They are known to agree exactly; re-measuring keeps every
+    // ratio below anchored to a number produced in this same run.
+    let fp_tape = perplexity_windowed(&fp, &arch, &tokens, WINDOW);
+    println!("fp / tape (A-fp32)   : {fp_tape:.3}");
+
+    let root = std::env::temp_dir().join(format!("tritium-a8-{}", std::process::id()));
+    let mut rows: Vec<(usize, f64, f64)> = Vec::new();
+
+    for planes in PLANE_COUNTS {
+        // A-fp32: the fitter's dense reconstruction on the tape — the basis of every published
+        // SALT number.
+        let fitted: Vec<Vec<f32>> = fp
+            .iter()
+            .zip(&shapes)
+            .map(|(w, &(n, k))| {
+                ste::salt_quantize_forward_grouped_geometric(
+                    w,
+                    n,
+                    k,
+                    planes,
+                    GROUP,
+                    GRID,
+                    RotationPolicy::Never,
+                )
+            })
+            .collect();
+        let a_fp32 = perplexity_windowed(&fitted, &arch, &tokens, WINDOW);
+        drop(fitted);
+
+        // A-int8: the same fit, written by `tritium convert` and executed by the shipping runtime.
+        let out = root.join(format!("t{planes}"));
+        let _ = std::fs::remove_dir_all(&out);
+        let status = Command::new(tritium_bin())
+            .args([
+                "convert",
+                "--model",
+                model.to_str().unwrap(),
+                "--out",
+                out.to_str().unwrap(),
+                "--planes",
+                &planes.to_string(),
+                "--group",
+                &GROUP.to_string(),
+                "--grid",
+                &GRID.to_string(),
+                "--fold-alpha",
+                "0",
+            ])
+            .status()
+            .expect("run tritium convert");
+        assert!(status.success(), "convert failed at T={planes}");
+
+        let mut r = ModelRunner::from_salt(
+            &out,
+            &out.join("model.tslb"),
+            Box::new(tritium_cpu::CpuBackend::new()),
+        )
+        .expect("load converted artifact");
+        let a_int8 = teacher_forced_perplexity_windows(&mut r, &tokens, WINDOW)
+            .expect("score artifact")
+            .perplexity;
+        drop(r);
+        let _ = std::fs::remove_dir_all(&out);
+
+        println!(
+            "T={planes}: A-fp32 {a_fp32:.3} ({:.4}x fp) | A-int8 {a_int8:.3} ({:.4}x fp) | A8 tax \
+             {:+.2}%",
+            a_fp32 / fp_tape,
+            a_int8 / fp_tape,
+            100.0 * (a_int8 - a_fp32) / a_fp32
+        );
+        rows.push((planes, a_fp32, a_int8));
+    }
+
+    println!("\n--- int8 activation tax by plane count ---");
+    for (planes, a_fp32, a_int8) in &rows {
+        println!(
+            "T={planes}  weights-only {:.4}x fp  ->  deployed {:.4}x fp   (tax {:+.2}%)",
+            a_fp32 / fp_tape,
+            a_int8 / fp_tape,
+            100.0 * (a_int8 - a_fp32) / a_fp32
+        );
+    }
+    println!(
+        "\nEvery published SALT perplexity is the 'weights-only' column. The 'deployed' column is \
+         what `tritium convert` + `ModelRunner` produce."
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes the adoption spine. `tritium convert` wrote a ternary model directory that **nothing in the CLI could consume** — `generate` was GGUF-only, `report` takes fp masters — so the artifact was library-loadable and CLI-unrunnable, and *acquire → convert → run* stopped one step short of running anything.

End to end on SmolLM2-135M, converted at T=4/g256 (8.25 bpw, 169.6 MiB bundle):

```
$ tritium generate --model <dir> --prompt "The capital of France is"
 Paris.
```

## Dispatch on content, not on spelling

`--model` accepts a `.gguf` file or a directory holding `model.tslb`. Deciding by **content** means a mistyped path fails as "not a model" rather than being silently treated as the other kind, and a directory without a bundle names the file it's missing instead of surfacing a bare `EISDIR` from `std::fs::read`.

## `--tokens` and `--prompt` are different contracts

Mutually exclusive on purpose — not two spellings of one thing.

- `--tokens` promises **exact ids in, exact ids out**, no tokenizer in the loop. It stays the reproducible path.
- `--prompt` uses the **model's own** tokenizer: `tokenizer.json` from a converted directory (which `convert` copies for exactly this reason), or the BPE embedded in a GGUF.

There is deliberately **no fallback tokenizer**. Token ids are only meaningful relative to the vocabulary that produced them, so a default would generate confident nonsense. Decoded text is printed only when text went in.

## The int8-activation measurement

`a8_activation_cost` answers a question raised while gating WS-3: every published SALT perplexity is **W-ternary / A-fp32** (harnesses score dense reconstructions through `Tape::dense_matmul`), while the shipping runtime is **W-ternary / A-int8** (`SaltLinear::forward` calls `quantize_activation_int8` before every projection).

T=4 reproduced the independent `convert_anchor_diagnostic` **exactly** (18.746 / 19.263) from a separately-written harness.

| T | weights-only | deployed | tax on ppl | **excess over fp** |
|---|---|---|---|---|
| 3 | 1.3440× | 1.3889× | +3.33% | 34.40% → 38.89% (1.13×) |
| 4 | 1.0277× | 1.0560× | +2.76% | 2.77% → **5.60%** (**2.02×**) |

**The tax column is the misleading one.** ~3% of perplexity at both plane counts reads like a constant additive cost that could be footnoted. As a fraction of the *excess over fp* — which is what a parity claim actually asserts — int8 activations **double** the gap at T=4 and add only 13% at T=3. A8 costs a *good* weight quantizer more than a mediocre one, because there's less weight error left for it to hide behind.

**Roadmap consequence:** at T=4, recovering the A8 loss beats adding a fifth plane. The plane buys a fraction of the remaining 2.77% weight excess; finer-grained activation scales target 2.83 points taken in full today.

## Gate

`cargo fmt --check` clean; `clippy -p tritium-cli -p tritium-nn --all-targets` clean; 47 CLI tests pass. **Three of the four new `generate` tests need no model** and run in normal CI — the mutual-exclusion, the required-one-of, and the directory-without-a-bundle refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4