### PR TITLE
build(deps): bump the three dependency majors that are drop-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,17 +161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.4",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,11 +180,10 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -210,8 +198,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "sync_wrapper",
@@ -223,19 +210,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -465,14 +450,15 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
+checksum = "5ecb245093b0f791b89d3420c3df9c6d49c60ab63ba54db896bf8a3baf486706"
 dependencies = [
  "byteorder",
- "float8 0.6.1",
+ "float8 0.7.0",
  "gemm",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -482,7 +468,9 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror 2.0.20",
+ "tokenizers 0.22.2",
  "yoke",
+ "zerocopy",
  "zip",
 ]
 
@@ -1540,9 +1528,9 @@ dependencies = [
 
 [[package]]
 name = "float8"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
@@ -2429,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -2929,9 +2917,9 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "pollster"
-version = "0.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "portable-atomic"
@@ -3443,13 +3431,15 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3900,6 +3890,39 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.20",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokenizers"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
@@ -4121,7 +4144,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "tokenizers",
+ "tokenizers 0.23.1",
  "tritium-core",
  "tritium-cpu",
  "tritium-cuda",
@@ -4236,7 +4259,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "tokenizers",
+ "tokenizers 0.23.1",
  "tritium-core",
  "tritium-cpu",
  "tritium-cuda",
@@ -5291,9 +5314,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ cbindgen = "0.29"
 # Vulkan-only mask yields zero adapters on every Mac. The feature is a no-op on
 # non-Apple targets (wgpu-hal cfgs the backend out), so it costs Linux nothing.
 wgpu = { version = "=23.0.1", default-features = false, features = ["wgsl", "metal"] }
-pollster = "0.4"
+pollster = "1.0"
 # metal backend (MSL mpGEMM over Apple Metal, tritium-metal). metal-rs is declared under
 # tritium-metal's [target.'cfg(target_os = "macos")'] table, so it is NEVER resolved on a
 # non-macOS host. Exact pin keeps cargo-deny wildcards=deny meaningful. (tritium-rocm needs no
@@ -115,7 +115,7 @@ ndarray = { version = "=0.17.2", default-features = false, features = ["std"] }
 ort = { version = "=2.0.0-rc.12", default-features = false }
 prost = "0.14"
 # candle interop (tritium-candle, behind its `candle` feature; CPU-only — no cuda/mkl/accelerate)
-candle-core = { version = "0.9", default-features = false }
+candle-core = { version = "0.11", default-features = false }
 # burn interop (tritium-burn, behind its `burn` feature; CPU-only NdArray backend in the test).
 # burn-tensor gives Tensor/Backend/TensorData; burn-ndarray is the concrete CPU backend. `std`
 # (needed for NdArray + TensorData::to_vec) pulls the MPL-2.0 `colored` crate (allow-listed in deny.toml).
@@ -129,7 +129,7 @@ anyhow = "1"
 memmap2 = "0.9"
 # serve (OpenAI HTTP/SSE server; all behind tritium-serve's `serve` feature)
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "macros", "signal", "time", "sync"] }
-axum = { version = "0.7", default-features = false, features = ["http1", "json", "tokio"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio"] }
 async-stream = "0.3"
 futures-core = "0.3"
 http-body-util = "0.1"


### PR DESCRIPTION
Continues the #12 split. #14 took the semver-compatible half; these are three of the majors it excluded that turn out to need **no migration at all**. Tested one at a time, each with the feature that actually compiles it.

| crate | from → to | consumer |
|---|---|---|
| pollster | 0.4.0 → 1.0.1 | `tritium-wgpu`, `--features wgpu` |
| axum | 0.7.9 → 0.8.9 | `tritium-serve`, `--features serve` |
| candle-core | 0.9.2 → 0.11.0 | `tritium-candle`, `--features candle` |

**Zero source changes** — only the workspace manifest and lock move.

## Two vacuous "passes" caught on the way

Worth stating, because a green check that never compiled the dependency is worse than a red one:

- **`pollster` is a dev-dependency** of `tritium-wgpu`, so `cargo check -p tritium-wgpu` never built it. Needs `--all-targets`.
- **`wgpu` and `pollster` are optional behind `--features wgpu`**, and `tritium-wgpu` is `default = []`. My first run compiled *neither* — while `backend.rs` alone has **467 `wgpu::` call sites**.

Every result below was re-taken with the feature enabled and the dependency confirmed present via `cargo tree -i`.

## The four that are *not* drop-in, with their actual blockers

| crate | errors | blocker |
|---|---|---|
| sha2 0.10.9 → 0.11.0 | 6 | Digest output is now `Array<u8, ..>`, which doesn't implement `LowerHex` — every `format!("{:x}", digest)` breaks. Needs a hex encoder (`base16ct`/`hex`). Touches 3 crates. |
| wgpu 23.0.1 → 26.0.1 | 33 | `wgpu::Maintain` is gone; the device-poll API changed shape. |
| ort rc.12 → rc.13 | 65 | `ort::operator::KernelAttributes` moved; `min_version`/`max_version` dropped from trait `Operator`. |
| burn 0.20.1 → 0.21.0 | — | **Not a code migration.** `rustc 1.89.0 is not supported by the following package` — burn 0.21 raises its MSRV above this repo's pinned toolchain. Blocked on a *toolchain decision*, not on porting effort. |

The burn one is the interesting result: it would have looked like an ordinary migration until you try it, and it isn't one.

## Gate

`cargo check --locked --workspace --exclude tritium-py --all-targets` clean; `cargo clippy --all-targets -- -D warnings` clean across all three feature lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4