### PR TITLE
test(deltanet): pin the duplicated activation kernels with golden vectors (ADR 0039 WS-G)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,6 +4244,7 @@ dependencies = [
  "tritium-quantize",
  "tritium-runtime",
  "tritium-spec",
+ "tritium-testkit",
  "tritium-train",
 ]
 

--- a/crates/tritium-nn/Cargo.toml
+++ b/crates/tritium-nn/Cargo.toml
@@ -39,6 +39,10 @@ serde_json = { workspace = true }
 tokenizers = { workspace = true, optional = true }
 
 [dev-dependencies]
+# Golden vectors pinning the DeltaNet activation kernels, which are duplicated in tritium-onnx
+# purely so the two backends agree (ADR 0039 WS-G). testkit does not depend on tritium-nn, so
+# this dev-only edge introduces no cycle.
+tritium-testkit = { workspace = true }
 proptest = { workspace = true }
 # A concrete backend for the layer/forward integration tests (WF-3): the layers
 # speak the `tritium-spec` contract, so the tests drive them through the CPU

--- a/crates/tritium-nn/src/layers/qwen35_deltanet.rs
+++ b/crates/tritium-nn/src/layers/qwen35_deltanet.rs
@@ -866,3 +866,16 @@ mod tests {
         assert!(cache.is_empty());
     }
 }
+
+#[cfg(test)]
+mod activation_parity {
+    /// The ONNX backend carries a character-for-character copy of these three functions
+    /// (`deltanet_softplus`/`_sigmoid`/`_silu` in `tritium-onnx`). The duplication exists solely so
+    /// the two backends agree, and nothing asserted that until this test. `tritium-onnx` runs the
+    /// same vectors against its copy, so a change to either side now fails rather than silently
+    /// diverging. See ADR 0039 WS-G.
+    #[test]
+    fn native_activations_match_the_shared_golden_vectors() {
+        tritium_testkit::assert_deltanet_activations(super::softplus, super::sigmoid, super::silu);
+    }
+}

--- a/crates/tritium-onnx/src/onnx_op.rs
+++ b/crates/tritium-onnx/src/onnx_op.rs
@@ -4721,3 +4721,18 @@ mod tests {
             .0
     }
 }
+
+#[cfg(test)]
+mod deltanet_activation_parity {
+    /// The native DeltaNet in `tritium-nn` carries a character-for-character copy of these three
+    /// functions. Both crates assert the same golden vectors, so a change to either copy fails
+    /// here instead of producing a silent backend divergence. See ADR 0039 WS-G.
+    #[test]
+    fn onnx_activations_match_the_shared_golden_vectors() {
+        tritium_testkit::assert_deltanet_activations(
+            super::deltanet_softplus,
+            super::deltanet_sigmoid,
+            super::deltanet_silu,
+        );
+    }
+}

--- a/crates/tritium-testkit/src/deltanet_activations.rs
+++ b/crates/tritium-testkit/src/deltanet_activations.rs
@@ -1,0 +1,82 @@
+//! Golden vectors pinning the DeltaNet activation kernels across backends.
+//!
+//! `softplus`, `sigmoid` and `silu` exist **twice** in this workspace, character for character:
+//! once in `tritium-nn` (`layers/qwen35_deltanet.rs`, the native DeltaNet recurrence) and once in
+//! `tritium-onnx` (`onnx_op.rs`, as `deltanet_*`). The duplication has exactly one purpose —
+//! cross-backend agreement — and nothing asserted it. Two copies of a numeric kernel whose only
+//! job is to agree is a latent parity bug: either can be "cleaned up" and the other will not
+//! notice.
+//!
+//! # Why this is a table and not a shared function (yet)
+//!
+//! De-duplicating properly means one definition in `tritium-core`, and that is blocked on ADR 0039
+//! WS-A for a load-bearing reason: `tritium-core` is `no_std`-able and contains **zero
+//! transcendentals**, which is precisely the property `tritium-mcu` cites for CPU↔MCU byte
+//! identity. Moving `value.exp().ln_1p()` there today would trade this latent parity bug for a
+//! broken byte-identity claim. The other candidate, sharing via `tritium-nn`, needs a new
+//! dependency edge because `tritium-onnx` only pulls it behind `qwen-package` while the ONNX ops
+//! sit behind `onnx`.
+//!
+//! So until WS-A supplies an exact/LUT form, this table pins the agreement instead. Delete it when
+//! the two copies collapse into one.
+//!
+//! # What it does and does not guarantee
+//!
+//! Bits are recorded from the `tritium-nn` implementation on x86-64 Linux. Asserting them from
+//! both crates catches **drift between the copies**, which is the actual failure mode. It is *not*
+//! a cross-platform bit-identity claim: both sides call the same libm, so both would move together
+//! on a platform whose `exp`/`ln_1p` differ. That caveat is the second half of ADR 0039 WS-G —
+//! stated here rather than left implied.
+
+/// `(input, softplus_bits, sigmoid_bits, silu_bits)`, as raw `f32` bit patterns so the comparison
+/// is exact rather than an epsilon that could hide a real divergence.
+///
+/// Inputs cover both `softplus` branches and the boundary between them (`> 20.0`), the sign
+/// change, and the saturating tails.
+pub const DELTANET_ACTIVATION_VECTORS: &[(f32, u32, u32, u32)] = &[
+    (-3e1, 0x29d2_b706, 0x29d2_b707, 0xac45_8b97),
+    (-8e0, 0x39af_d97b, 0x39af_d1ef, 0xbb2f_d1ef),
+    (-1.5e0, 0x3e4e_3f49, 0x3e3a_cdc2, 0xbe8c_1a52),
+    (-5e-1, 0x3ef2_ba38, 0x3ec1_4d03, 0xbe41_4d03),
+    (0e0, 0x3f31_7218, 0x3f00_0000, 0x0000_0000),
+    (5e-1, 0x3f79_5d1c, 0x3f1f_597f, 0x3e9f_597f),
+    (1.5e0, 0x3fd9_c7e9, 0x3f51_4c8f, 0x3f9c_f96b),
+    (8e0, 0x4100_0160, 0x3f7f_ea06, 0x40ff_ea06),
+    // 19.9 and 20.0 both take the `else` branch; in f32 `ln_1p(exp(x))` has already saturated to
+    // x by here, so the branch at `> 20.0` is continuous. Pinned so a change to the threshold
+    // shows up as a diff rather than as silence.
+    (1.99e1, 0x419f_3333, 0x3f80_0000, 0x419f_3333),
+    (2e1, 0x41a0_0000, 0x3f80_0000, 0x41a0_0000),
+    (2.01e1, 0x41a0_cccd, 0x3f80_0000, 0x41a0_cccd),
+    (3e1, 0x41f0_0000, 0x3f80_0000, 0x41f0_0000),
+];
+
+/// Assert one implementation triple against [`DELTANET_ACTIVATION_VECTORS`].
+///
+/// Takes the three functions so each crate can pass its own private copies without exporting them.
+///
+/// # Panics
+/// Panics naming the function, the input, and both bit patterns when any value disagrees.
+pub fn assert_deltanet_activations(
+    softplus: impl Fn(f32) -> f32,
+    sigmoid: impl Fn(f32) -> f32,
+    silu: impl Fn(f32) -> f32,
+) {
+    for &(x, want_softplus, want_sigmoid, want_silu) in DELTANET_ACTIVATION_VECTORS {
+        for (name, got, want) in [
+            ("softplus", softplus(x).to_bits(), want_softplus),
+            ("sigmoid", sigmoid(x).to_bits(), want_sigmoid),
+            ("silu", silu(x).to_bits(), want_silu),
+        ] {
+            assert_eq!(
+                got,
+                want,
+                "{name}({x}) = 0x{got:08x} ({}), expected 0x{want:08x} ({}). The native and ONNX \
+                 DeltaNet activations are duplicated on purpose and must agree bit-for-bit; a diff \
+                 here means one copy moved. See ADR 0039 WS-G.",
+                f32::from_bits(got),
+                f32::from_bits(want),
+            );
+        }
+    }
+}

--- a/crates/tritium-testkit/src/lib.rs
+++ b/crates/tritium-testkit/src/lib.rs
@@ -35,6 +35,7 @@
 #![deny(missing_docs)]
 
 mod codec_vectors;
+mod deltanet_activations;
 mod frozen;
 mod generate;
 mod jsonl;
@@ -47,6 +48,7 @@ mod vector;
 pub use codec_vectors::{
     Conv1dVector, FsqVector, generate_conv_vectors, generate_fsq_vectors, grade_conv, grade_fsq,
 };
+pub use deltanet_activations::{DELTANET_ACTIVATION_VECTORS, assert_deltanet_activations};
 pub use frozen::{
     FROZEN_COUNT, FROZEN_SEED, VECTOR_SET_VERSION, frozen_vectors, frozen_vectors_path,
 };


### PR DESCRIPTION
`softplus`, `sigmoid` and `silu` exist **twice** in this workspace, character for character — once in `tritium-nn` (`layers/qwen35_deltanet.rs`) and once in `tritium-onnx` (`onnx_op.rs`, as `deltanet_*`). The duplication has exactly one purpose, cross-backend agreement, and **nothing asserted it**. Two copies of a numeric kernel whose only job is to agree is a latent parity bug: either can be "cleaned up" and the other won't notice.

Both crates now assert the same `(input, softplus_bits, sigmoid_bits, silu_bits)` table from `tritium-testkit`. **Bits, not epsilons** — a real divergence can't hide under a tolerance.

## The gate has teeth — demonstrated, not assumed

Rewriting the ONNX sigmoid from `1/(1+e^-x)` to the **algebraically identical** `e/(1+e)` makes the test fail:

```
sigmoid(-30) = 0x29d2b706, expected 0x29d2b707
```

One ULP, from a refactor that looks like a pure cleanup — exactly what this exists to catch. Reverted; both crates green.

## Why a table instead of just de-duplicating

WS-G says to collapse the copies into `tritium-core` *"once WS-A lands"*, and that qualifier turns out to be load-bearing rather than scheduling:

- **`tritium-core` would lose the property it exists for.** It's `no_std`-able and contains **zero transcendentals** (verified by grep), and that absence is precisely what `tritium-mcu` cites for CPU↔MCU byte identity. Moving `value.exp().ln_1p()` there today trades a latent parity bug for a *broken byte-identity claim*.
- **Sharing via `tritium-nn` needs a new dependency edge** — `tritium-onnx` only pulls it behind `qwen-package`, while the ONNX ops sit behind `onnx`.

So this pins the agreement until WS-A supplies an exact/LUT form. Delete the table when the copies collapse.

## Scope note, recorded in the module itself

These bits are **not** a cross-platform bit-identity claim: both sides call the same libm, so both would move together on a platform whose `exp`/`ln_1p` differ. This catches drift **between the copies**, which is the actual failure mode. That was the second half of WS-G — *"document the real guarantee"* — now stated rather than implied.

`tritium-nn` gains a dev-only edge on `tritium-testkit`; testkit doesn't depend on `tritium-nn`, so there's no cycle.

## Gate

fmt clean; `clippy -D warnings` clean for `tritium-testkit`, `tritium-nn`, and `tritium-onnx --features onnx`.

Worth knowing: **the onnx test only compiles with that feature.** Without it the run reports `0 passed; 73 filtered out` and proves nothing — which is how it first appeared to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4