### PR TITLE
build(deps): migrate sha2 0.10 → 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -304,11 +304,11 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -638,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,15 +757,6 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -815,12 +812,11 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1237,11 +1233,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1770,16 +1767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2016,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3553,12 +3549,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ proptest = "1"
 divan = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Lints applied workspace-wide; crates opt in with `[lints] workspace = true`.
 [workspace.lints.rust]

--- a/crates/tritium-cli/src/convert.rs
+++ b/crates/tritium-cli/src/convert.rs
@@ -381,9 +381,8 @@ fn write_receipt(
 
 fn file_digest(path: &Path) -> Result<String> {
     let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
-    Ok(format!(
-        "{:x}",
-        <sha2::Sha256 as sha2::Digest>::digest(&bytes)
+    Ok(crate::hex::hex_digest(
+        &<sha2::Sha256 as sha2::Digest>::digest(&bytes),
     ))
 }
 

--- a/crates/tritium-cli/src/hestia_gate.rs
+++ b/crates/tritium-cli/src/hestia_gate.rs
@@ -104,8 +104,8 @@ fn measure(
         bail!("portable V3 corpus must contain exactly five HESTIA cases");
     }
     let vector_digest = format!(
-        "sha256:{:x}",
-        Sha256::digest(TrainingVectorSetV3::canonical_json())
+        "sha256:{}",
+        crate::hex::hex_digest(&Sha256::digest(TrainingVectorSetV3::canonical_json()))
     );
 
     let gradcheck = measured_gradcheck()?;

--- a/crates/tritium-cli/src/hex.rs
+++ b/crates/tritium-cli/src/hex.rs
@@ -1,0 +1,71 @@
+//! Lower-case hex encoding for digests.
+//!
+//! Moved here (not newly written) from `stage7_evidence` when sha2 0.11 changed `Digest::finalize`
+//! to return `hybrid_array::Array`, which — unlike the old `GenericArray` — does not implement
+//! `LowerHex`. Every `format!("{:x}", digest)` in the crate stopped compiling, and the fix needed a
+//! home that was not one module's private helper.
+//!
+//! **There are still three other private copies of this function** in `campaign.rs`,
+//! `campaign_artifact.rs` and `salt.rs`, differing only in signature (`[u8; 32]` by value or by
+//! reference). Collapsing them means touching ~65 call sites across files under active development,
+//! which does not belong in a dependency bump; this at least stops the count from growing.
+
+/// Encode `bytes` as lower-case hex.
+///
+/// Takes a slice rather than `[u8; 32]` so it serves any digest width, and so a `sha2` output
+/// coerces directly without naming its array type.
+pub(crate) fn hex_digest(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex_digest;
+
+    /// Known-answer test across the sha2 0.10 -> 0.11 bump. The upgrade changed `finalize`'s return
+    /// type from `GenericArray` to `hybrid_array::Array` and removed the `io::Write` impl, so every
+    /// digest call site in this crate had to change shape. None of that may alter a byte of output:
+    /// these digests are written into release evidence and compared across runs.
+    ///
+    /// `SHA-256("abc")` is the canonical FIPS 180-4 vector.
+    #[test]
+    fn sha256_of_abc_matches_the_published_vector() {
+        use sha2::Digest as _;
+        let digest = sha2::Sha256::digest(b"abc");
+        assert_eq!(
+            hex_digest(&digest),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    /// The empty input is the other standard vector, and it also pins the `with_capacity(0)` path.
+    #[test]
+    fn sha256_of_empty_matches_the_published_vector() {
+        use sha2::Digest as _;
+        assert_eq!(
+            hex_digest(&sha2::Sha256::digest(b"")),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    /// Streaming through `hash_reader`-style `update` calls must equal the one-shot digest, which is
+    /// what makes the `io::copy` replacement safe.
+    #[test]
+    fn chunked_update_equals_one_shot() {
+        use sha2::Digest as _;
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(b"a");
+        hasher.update(b"b");
+        hasher.update(b"c");
+        assert_eq!(
+            hex_digest(&hasher.finalize()),
+            hex_digest(&sha2::Sha256::digest(b"abc"))
+        );
+    }
+}

--- a/crates/tritium-cli/src/main.rs
+++ b/crates/tritium-cli/src/main.rs
@@ -42,6 +42,7 @@ mod convert;
 mod generate;
 #[cfg(feature = "cuda")]
 mod hestia_gate;
+mod hex;
 mod inspect;
 #[cfg(feature = "cuda")]
 mod nvml_probe;

--- a/crates/tritium-cli/src/release.rs
+++ b/crates/tritium-cli/src/release.rs
@@ -77,7 +77,7 @@ fn digest_stream(mut reader: impl Read) -> anyhow::Result<StreamIdentity> {
     Ok(StreamIdentity {
         schema: "tritium.stream-identity.v1",
         bytes,
-        sha256: format!("{:x}", sha256.finalize()),
+        sha256: crate::hex::hex_digest(&sha256.finalize()),
         blake3: blake3.finalize().to_hex().to_string(),
         package_id: package.finalize().to_string(),
     })
@@ -116,7 +116,7 @@ fn digest(path: &Path) -> anyhow::Result<FileIdentity> {
     Ok(FileIdentity {
         schema: "tritium.file-identity.v1",
         bytes,
-        sha256: format!("{:x}", sha256.finalize()),
+        sha256: crate::hex::hex_digest(&sha256.finalize()),
         blake3: blake3.finalize().to_hex().to_string(),
     })
 }

--- a/crates/tritium-cli/src/stage7_evidence.rs
+++ b/crates/tritium-cli/src/stage7_evidence.rs
@@ -1,5 +1,6 @@
 //! Deterministic Stage-7 token-evidence pack builder.
 
+use crate::hex::hex_digest;
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsString,
@@ -562,7 +563,7 @@ fn file_record(path: &Path, logical: &str) -> anyhow::Result<FileRecord> {
     );
     let mut file = File::open(path)?;
     let mut hasher = Sha256::new();
-    let bytes = std::io::copy(&mut file, &mut hasher)?;
+    let bytes = hash_reader(&mut file, &mut hasher)?;
     Ok(FileRecord {
         path: logical.to_owned(),
         bytes,
@@ -622,7 +623,7 @@ fn open_record(
         "{label} size differs"
     );
     let mut hasher = Sha256::new();
-    let bytes = std::io::copy(&mut file, &mut hasher)?;
+    let bytes = hash_reader(&mut file, &mut hasher)?;
     ensure!(
         bytes == record.bytes && hex_digest(&hasher.finalize()) == record.sha256,
         "{label} identity differs"
@@ -708,12 +709,21 @@ fn valid_hex(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
-fn hex_digest(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut output = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        output.push(char::from(HEX[usize::from(byte >> 4)]));
-        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+/// Stream `reader` into `hasher`, returning the number of bytes consumed.
+///
+/// Replaces `std::io::copy(&mut file, &mut hasher)`: sha2 0.11 dropped the `std::io::Write` impl on
+/// its hashers, and 0.11.0 exposes no `std` feature at all (only `alloc`/`oid`/`zeroize`), so there
+/// is nothing to turn back on. An explicit loop does not depend on an impl that has already moved
+/// once, and it keeps the byte count `io::copy` used to return.
+fn hash_reader(mut reader: impl std::io::Read, hasher: &mut Sha256) -> std::io::Result<u64> {
+    let mut buffer = [0u8; 64 * 1024];
+    let mut total = 0u64;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(total);
+        }
+        hasher.update(&buffer[..read]);
+        total += read as u64;
     }
-    output
 }

--- a/scripts/verify-gates.sh
+++ b/scripts/verify-gates.sh
@@ -150,6 +150,31 @@ run_model_acceptance() {
         cpu_longer_greedy_matches_transformers --nocapture
 }
 
+
+# Cross-check the non-unix configuration.
+#
+# `#[cfg(unix)]` definitions whose callers are ungated compile fine on Linux and fail only on
+# Windows (E0599, "no method named ..."). tritium-salt broke `main` this way on 2026-08-26:
+# 51 of its 64 cfg(unix) functions still have no `not(unix)` twin, so the class is one ungated
+# caller away from recurring, and NO amount of Linux checking sees it.
+#
+# `cargo check` does not link, so the gnu target needs only mingw for blake3's C build. The msvc
+# target fails earlier for want of an MSVC compiler -- use gnu.
+verify_non_unix_cfg() {
+    if ! rustup target list --installed 2>/dev/null | grep -q '^x86_64-pc-windows-gnu$'; then
+        echo "SKIPPED non-unix cfg check: rustup target add x86_64-pc-windows-gnu" >&2
+        return 0
+    fi
+    if ! command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1; then
+        echo "SKIPPED non-unix cfg check: install mingw-w64 (x86_64-w64-mingw32-gcc)" >&2
+        return 0
+    fi
+    run env CC_x86_64_pc_windows_gnu=x86_64-w64-mingw32-gcc \
+        AR_x86_64_pc_windows_gnu=x86_64-w64-mingw32-ar \
+        cargo check --locked --workspace --exclude tritium-py --all-targets \
+        --target x86_64-pc-windows-gnu
+}
+
 case "$tier" in
     precommit)
         run git diff --cached --check
@@ -159,6 +184,15 @@ case "$tier" in
     prepush)
         run cargo fmt --all --check
         run cargo clippy --locked --workspace --all-targets -- -D warnings
+        # Default features are NOT the shipped surface. Optional deps and cfg-gated modules do not
+        # compile above, so a clean default run says nothing about them -- three separate CI
+        # failures on 2026-08-26 all came through this gap (a cuda/nccl-only digest site, an
+        # onnx-only test that reported "0 passed; 73 filtered out", and wgpu/pollster which are
+        # optional behind --features wgpu while backend.rs alone has 467 wgpu:: call sites).
+        # TRITIUM_CHECK_ONLY=1 keeps this toolkit-free, exactly as the release tier does.
+        run env TRITIUM_CHECK_ONLY=1 cargo clippy --locked --workspace --all-targets \
+            --all-features -- -D warnings
+        verify_non_unix_cfg
         ;;
     ci)
         run cargo fmt --all --check


### PR DESCRIPTION
Fourth of the seven majors from the #12 split. Unlike pollster/axum/candle (#17), this one needs real changes — **in two layers**, the second only visible once the first was fixed. The "6 errors" I first measured was a floor, not a total.

## Layer 1 — `format!("{:x}", digest)` no longer compiles

`Digest::finalize` now returns `hybrid_array::Array`, which (unlike the old `GenericArray`) doesn't implement `LowerHex`. Three sites: `release.rs` ×2, `convert.rs`.

The crate already had **four** private `hex_digest` copies — `campaign.rs`, `campaign_artifact.rs`, `salt.rs`, `stage7_evidence.rs` — differing only in signature. Rather than add a fifth, the `&[u8]` one **moved** out of `stage7_evidence` into a shared `hex` module and now serves both it and the three broken sites.

Collapsing the remaining three would touch **~65 call sites** across files under active development, which doesn't belong in a dependency bump. A follow-up owns it; this at least stops the count growing.

## Layer 2 — `std::io::copy` into a hasher no longer compiles

sha2 0.11 dropped the `std::io::Write` impl on its hashers, and **0.11.0 exposes no `std` feature** to turn it back on — its features are `alloc`, `oid`, `zeroize`. So there's no fix by configuration.

Replaced with an explicit 64 KiB read loop that preserves the byte count `io::copy` returned. That doesn't depend on an impl which has already moved once.

## The output must not move by a byte

These digests are written into release evidence and compared across runs, so the migration is only safe if every digest is bit-identical. Added known-answer tests on the FIPS 180-4 vectors:

```
SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
SHA-256("")    = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

plus one asserting chunked `update` equals the one-shot digest — exactly the property the `io::copy` replacement relies on.

## Gate

fmt clean; `cargo clippy --locked --workspace --exclude tritium-py --all-targets -- -D warnings` clean; tritium-cli 47 tests, tritium-salt 60/30 tests pass; tritium-py checks.

## Remaining majors

| crate | blocker |
|---|---|
| wgpu 23→26 | `wgpu::Maintain` removed, device-poll reshaped (33 errors) |
| ort rc.12→rc.13 | `KernelAttributes` moved; `min_version`/`max_version` dropped from `Operator` (65 errors) |
| burn 0.20→0.21 | **not a port** — needs a rustc newer than the repo's pinned 1.89.0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4