### PR TITLE
docs: research is promoted on implementation, not on completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,13 @@ scratch_st/
 
 # Research/ADR/plan docs live in the private tritium-research repo (docs/RESEARCH.md);
 # working copies remain on disk for active sessions but are untracked.
-docs/adr/
+# Research records are default-DENY here. The working front lives in the private
+# tritium-research repo; a record appears in this repo only once its decision has
+# shipped (docs/RESEARCH.md). Promotion is an explicit un-ignore of one file, which
+# is the forcing function: you cannot publish a record by accident, and the .gitignore
+# diff is the promotion audit trail.
+docs/adr/*
+!docs/adr/README.md
 docs/plans/
 docs/paper/
 docs/research-*.md

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,24 +1,57 @@
 # Research, ADRs, and campaign plans
 
-Tritium's research notes, Architecture Decision Records, preregistered
-campaign plans, benchmark-receipt archives, and the living roadmap are
-maintained in a separate repository and **published alongside their
-results**, not before.
+Tritium's research runs in two repositories, and the split is about **signal**, not
+secrecy.
 
-Preregistration is load-bearing here: quality campaigns (for example the
-Qwen3.6-27B flagship conversion gating v1.1 stable) freeze their acceptance
-thresholds *before* any scored run, and the frozen gates are re-published
-with the results — pass or fail — so a claim can never be quietly moved
-after the fact.
+| | repository | holds |
+|---|---|---|
+| working front | `Quitetall/tritium-research` (private) | every ADR, preregistered campaign plan, benchmark-receipt archive, and the living roadmap — including the ones that go nowhere |
+| this repo | `Quitetall/tritium` (public) | the records whose decision **shipped**, promoted once the code lands |
 
-What lives in-repo instead:
+Most research does not survive contact with measurement. This project has refuted its
+own levers repeatedly — a ternary teacher turned out to be redundant, per-group
+curvature allocation measured *worse* than uniform, a flash drafter was deleted after
+a −2.7% end-to-end result. Those refutations are real work and they are kept, but
+publishing all of them here would bury the handful of decisions a reader of this
+codebase actually needs.
 
-- [`docs/BENCHMARKS.md`](./BENCHMARKS.md) — the reproducible benchmark
-  ledger (every number beside its exact command and environment).
-- [`docs/compatibility.md`](./compatibility.md) — the generated,
-  receipt-backed support matrix.
+So the public record is not "all our research". It is **the research that became
+code**.
+
+## Promotion rule
+
+An ADR moves from the private repo into `docs/adr/` here when its decision has been
+implemented, and **the promoting pull request must cite the commit or PR that
+implemented it**. No implementation, no promotion — that is the whole mechanism, and
+it is deliberately manual: "did this actually ship, and does a reader benefit?" is a
+judgement, not a status field.
+
+(It could not be automated today in any case: of 41 ADRs, 18 carry no status line and
+exactly one says `IMPLEMENTED`. Normalising that vocabulary is worth doing on its own
+merits, but it is not what gates promotion.)
+
+Campaign plans follow the same rule and are promoted with the ADR they served, so a
+promoted decision arrives with the preregistered gate it was measured against.
+
+## On preregistration
+
+Preregistration is load-bearing: quality campaigns freeze their acceptance thresholds
+*before* any scored run, and a promoted plan is published with the gate it committed
+to — pass or fail — so a claim cannot be quietly moved after the fact.
+
+One honest caveat. Research documents were tracked in this repository until
+2026-07-30 and removed in `5b0fd3cc`. `git rm` does not rewrite history, so those
+files remain readable from this repository's history. Treat the pre-2026-07-30
+corpus as public. Everything after that date follows the rule above.
+
+## What lives here regardless
+
+- [`docs/BENCHMARKS.md`](./BENCHMARKS.md) — the reproducible benchmark ledger (every
+  number beside its exact command and environment).
+- [`docs/compatibility.md`](./compatibility.md) — the generated, receipt-backed
+  support matrix.
 - [`docs/ternary-formats.md`](./ternary-formats.md) — format documentation.
 - The mdbook under `docs/book/` — the user guide.
 
-Questions about a specific decision or plan? Open an issue — relevant
-records are published on request or with their results.
+Want a specific decision or plan? Open an issue. Records are promoted on request when
+the work they describe has shipped.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,28 @@
+# Promoted decision records
+
+This directory holds the ADRs whose decision **shipped**. It is not the full research
+record — see [`docs/RESEARCH.md`](../RESEARCH.md) for the split and the reason for it.
+
+Each entry names the change that implemented it. That citation is the promotion
+criterion: an ADR without one does not belong here yet.
+
+| ADR | decision | shipped in |
+|---|---|---|
+| _(none promoted yet)_ | | |
+
+## Promoting a record
+
+1. Confirm the decision is actually implemented in this repository — code merged, not
+   merely planned or measured.
+2. Copy the ADR from `Quitetall/tritium-research` into this directory, unchanged.
+   Promote the campaign plan it was measured against alongside it, so the
+   preregistered gate arrives with the decision.
+3. Add a row above citing the implementing PR or commit.
+4. If the record contains a claim later retracted, do not silently edit it — append a
+   dated amendment. The point of publishing a frozen gate is that it stays frozen.
+
+## Why this is manual
+
+"Did this ship, and does a reader of the codebase benefit from it?" is a judgement.
+It also cannot be derived from the records themselves today: of 41 ADRs, 18 carry no
+status line and exactly one says `IMPLEMENTED`.


### PR DESCRIPTION
Records the two-repo policy, and replaces a claim in `docs/RESEARCH.md` that is no longer true.

| | repository | holds |
|---|---|---|
| working front | `tritium-research` (private) | every ADR, plan, and receipt — **including the ones that go nowhere** |
| this repo | `tritium` (public) | records whose decision **shipped** |

Most research doesn't survive contact with measurement. This project has refuted its own levers repeatedly — a ternary teacher turned out redundant, per-group curvature allocation measured *worse* than uniform, a flash drafter was deleted after −2.7% end-to-end. Publishing all of it here would bury the handful of decisions a reader of this codebase actually needs.

**The public record is the research that became code.**

## The mechanism is a `.gitignore` negation, on purpose

`docs/adr/` was ignored wholesale. It's now **default-deny with per-file opt-in**:

```gitignore
docs/adr/*
!docs/adr/README.md
```

Promotion is an explicit un-ignore of one file. Two properties that matters for:

- **You cannot publish a record by accident.** 41 unpromoted ADRs sit untracked in that directory right now; `git add -A` stages none of them — verified, it stages only `.gitignore`.
- **The `.gitignore` diff *is* the promotion audit trail.**

`docs/adr/README.md` carries the index and checklist. The criterion: a promoting PR **must cite the commit or PR that implemented the decision**. No implementation, no promotion.

## Deliberately manual

"Did this ship, and does a reader benefit?" is a judgement. It also couldn't be automated today — of 41 ADRs, **18 carry no status line at all and exactly one says `IMPLEMENTED`**. Normalising that vocabulary is worth doing on its own merits, but it isn't what gates promotion.

## One claim corrected

The old text said research is *"published alongside their results, not before"*, and that preregistered gates stay sealed until then. Records were tracked here until 2026-07-30 and removed in `5b0fd3cc`; `git rm` doesn't rewrite history, so that corpus remains readable from this repository. `RESEARCH.md` now says so plainly rather than asserting a seal that doesn't hold.

Promoting on **implementation** is also stricter than promoting on results — a campaign can produce a result and still never ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4