### PR TITLE
ci(msrv): verify the floor with every feature on, not just the default set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,8 +529,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
           toolchain: ${{ steps.floor.outputs.version }}
-      - name: build the workspace at the floor
-        run: cargo +${{ steps.floor.outputs.version }} check --locked --workspace --exclude tritium-py --all-targets
+      # --all-features is load-bearing, not thoroughness theatre. Optional dependencies are
+      # invisible to a default-features check, so the floor would be verified only for the
+      # feature set nobody ships. Concretely: burn 0.21 requires rustc 1.92 via cubecl-zspace,
+      # and `tritium-burn` gates it behind `--features burn` -- a default-features MSRV lane
+      # passes while `rust-version = "1.89"` is false for any consumer who enables that
+      # feature. TRITIUM_CHECK_ONLY=1 keeps this toolkit-free, as the release tier does.
+      - name: build the workspace at the floor, every feature on
+        env:
+          TRITIUM_CHECK_ONLY: "1"
+        run: cargo +${{ steps.floor.outputs.version }} check --locked --workspace --exclude tritium-py --all-targets --all-features
 
   ci-required:
     name: ci-required


### PR DESCRIPTION
The `msrv` lane ran `cargo check --locked --workspace --all-targets` at the published floor — **default features**. Optional dependencies aren't compiled by that command, so the lane verified 1.89 for the one feature set nobody ships.

## How I found it

By trying to land burn 0.21, which became reachable once the build toolchain moved to 1.98:

```
cargo +1.89 check -p tritium-burn --features burn
→ error: rustc 1.89.0 is not supported by the following package:
         cubecl-zspace@0.10.0 requires rustc 1.92
```

`tritium-burn` gates burn behind `--features burn`, so **the old lane passes green while `rust-version = "1.89"` is false** for any consumer who enables it. That's precisely the promise this lane exists to keep, and it couldn't see the breach.

## The fix

`--all-features` at the floor. Verified locally: it **passes on main today**, so this closes the hole without changing the floor.

It also means a future dependency that raises its own MSRV fails *here, at the gate*, rather than in a downstream user's build — which is the entire point of pinning a floor.

`TRITIUM_CHECK_ONLY=1` keeps it toolkit-free, matching the release tier.

## Consequence for burn

burn 0.21 is **not** merged. With this lane in place it would fail, correctly. Landing it needs a deliberate decision — either raise the floor to ≥1.92, or give `tritium-burn` its own higher `rust-version` and accept a per-crate MSRV. Neither should happen as a side effect of a dependabot bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4