### PR TITLE
fix(oci): the container images could no longer build — and the test could not tell

### DIFF
--- a/deploy/oci/Dockerfile.cpu
+++ b/deploy/oci/Dockerfile.cpu
@@ -7,13 +7,13 @@ ARG SOURCE_DATE_EPOCH
 # pinned Rust; the shipped container building at the floor is a standing proof that the
 # floor actually works for a real artifact. Moving it means resolving a new base-image
 # digest and re-qualifying the image, which is its own change.
-FROM docker.io/library/rust:1.89.0-bookworm@sha256:c9ac3fa8945b61dede1e4500d25028aa8fd8a8fe46365fcf9c0422f8d999b9b0 AS build
+FROM docker.io/library/rust:1.98.0-bookworm@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922 AS build
 ARG SOURCE_REVISION
 ARG SOURCE_CREATED
 ARG SOURCE_DATE_EPOCH
 ARG CARGO_NET_OFFLINE=false
 ENV CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE} \
-    RUSTUP_TOOLCHAIN=1.89.0 \
+    RUSTUP_TOOLCHAIN=1.98.0 \
     TRITIUM_SOURCE_ID=source-git:${SOURCE_REVISION}
 WORKDIR /src
 COPY . .

--- a/deploy/oci/Dockerfile.cuda
+++ b/deploy/oci/Dockerfile.cuda
@@ -8,7 +8,7 @@ ARG SOURCE_DATE_EPOCH
 # pinned Rust; the shipped container building at the floor is a standing proof that the
 # floor actually works for a real artifact. Moving it means resolving a new base-image
 # digest and re-qualifying the image, which is its own change.
-FROM docker.io/library/rust:1.89.0-bookworm@sha256:c9ac3fa8945b61dede1e4500d25028aa8fd8a8fe46365fcf9c0422f8d999b9b0 AS rust-toolchain
+FROM docker.io/library/rust:1.98.0-bookworm@sha256:82150a52ec202c1b14d7817e14516c392bb7f5cfebd88f1ed531cb37ebd39922 AS rust-toolchain
 FROM docker.io/nvidia/cuda:13.0.1-devel-ubuntu22.04@sha256:bb3de902bc1b522231cffea98a4d25a16ddb9fc8685a958b48d83036f46fd0c2 AS build
 ARG SOURCE_REVISION
 ARG SOURCE_CREATED
@@ -20,7 +20,7 @@ ENV PATH=/usr/local/cargo/bin:${PATH} \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     CARGO_NET_OFFLINE=${CARGO_NET_OFFLINE} \
-    RUSTUP_TOOLCHAIN=1.89.0 \
+    RUSTUP_TOOLCHAIN=1.98.0 \
     TRITIUM_SOURCE_ID=source-git:${SOURCE_REVISION}
 WORKDIR /src
 COPY . .

--- a/scripts/tests/test_oci_contract.py
+++ b/scripts/tests/test_oci_contract.py
@@ -9,6 +9,25 @@ ROOT = Path(__file__).resolve().parents[2]
 DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
+def _ver(text: str) -> tuple[int, ...]:
+    """`1.98.0` -> (1, 98, 0), zero-padded so `1.96` and `1.96.0` compare equal."""
+    parts = tuple(int(p) for p in text.split("."))
+    return parts + (0,) * (3 - len(parts))
+
+
+def TOOLCHAIN_CHANNEL() -> str:
+    """The toolchain CI and the images build with, from rust-toolchain.toml."""
+    text = (ROOT / "rust-toolchain.toml").read_text(encoding="utf-8")
+    return re.search(r'(?m)^channel\s*=\s*"([^"]+)"', text).group(1)
+
+
+def WORKSPACE_MSRV() -> str:
+    """The published floor, from [workspace.package] rust-version -- not the build toolchain."""
+    text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    return re.search(r'(?m)^rust-version\s*=\s*"([^"]+)"', text).group(1)
+
+
+
 class OciContractTests(unittest.TestCase):
     def dockerfile(self, flavor: str) -> str:
         return (ROOT / f"deploy/oci/Dockerfile.{flavor}").read_text(encoding="utf-8")
@@ -80,7 +99,47 @@ class OciContractTests(unittest.TestCase):
         for flavor in ("cpu", "cuda"):
             text = self.dockerfile(flavor)
             self.assertIn("cargo build --frozen --profile dist", text)
-            self.assertIn("RUSTUP_TOOLCHAIN=1.89.0", text)
+
+    def test_image_toolchain_is_the_workspace_toolchain_and_clears_the_msrv(self):
+        """The images must build with the workspace toolchain, and it must satisfy the MSRV.
+
+        This assertion used to be ``assertIn("RUSTUP_TOOLCHAIN=1.89.0", text)`` -- a literal
+        that agreed with the Dockerfiles only because all three were edited together. When the
+        MSRV moved to 1.96 the Dockerfiles kept 1.89.0 and this test kept passing, because a
+        string match cannot notice that ``cargo`` now refuses the pair:
+
+            error: rustc 1.89.0 is not supported by the following packages:
+              tritium-core@1.1.0-rc.1 requires rustc 1.96
+
+        Nothing builds these images in CI, so the text match was the only thing standing
+        between a toolchain bump and a broken container. Deriving both ends removes the
+        constant that drifted.
+        """
+        channel = TOOLCHAIN_CHANNEL()
+        msrv = WORKSPACE_MSRV()
+        self.assertGreaterEqual(
+            _ver(channel),
+            _ver(msrv),
+            f"rust-toolchain.toml pins {channel}, below the workspace MSRV {msrv}",
+        )
+        for flavor in ("cpu", "cuda"):
+            text = self.dockerfile(flavor)
+            pinned = re.findall(r"RUSTUP_TOOLCHAIN=([0-9][^ \\\n]*)", text)
+            self.assertTrue(pinned, f"Dockerfile.{flavor} pins no RUSTUP_TOOLCHAIN")
+            for got in pinned:
+                self.assertEqual(
+                    got,
+                    channel,
+                    f"Dockerfile.{flavor} builds with {got} but rust-toolchain.toml pins {channel}",
+                )
+            # The base image must carry that same toolchain, or RUSTUP_TOOLCHAIN silently
+            # triggers a download at build time and the digest pin stops meaning anything.
+            for ref in re.findall(r"^FROM\s+(\S*library/rust:\S+)", text, flags=re.MULTILINE):
+                self.assertIn(
+                    f"rust:{channel}-",
+                    ref,
+                    f"Dockerfile.{flavor} base image {ref} disagrees with toolchain {channel}",
+                )
 
     def test_image_metadata_matches_source_contracts(self):
         cargo = (ROOT / "Cargo.toml").read_text(encoding="utf-8")


### PR DESCRIPTION
Raising the MSRV to 1.96 (#34) broke both OCI images. They pin `RUSTUP_TOOLCHAIN=1.89.0` on a digest-locked `rust:1.89.0-bookworm` base, and cargo refuses that pair outright:

```
error: rustc 1.89.0 is not supported by the following packages:
  tritium-build-info@1.1.0-rc.1 requires rustc 1.96
  tritium-core@1.1.0-rc.1 requires rustc 1.96
```

Reproduced with `cargo +1.89 check -p tritium-serve` against merged main. #34 updated `rust-toolchain.toml`, `ci.yml` and the threat model — it missed `deploy/oci`.

## Why CI stayed green

**Nothing builds these images.** `git grep -n 'docker\|oci' -- .github/workflows/` returns nothing; they're built by a local script, never in a workflow. The only thing watching the toolchain was:

```python
self.assertIn("RUSTUP_TOOLCHAIN=1.89.0", text)
```

A literal that agreed with the Dockerfiles only because all three were edited together — and that by construction cannot notice cargo rejecting the pair. Same shape as the vacuous-check class already recorded here: green because nothing compiled.

## The fix

Both images move to **1.98.0** — the toolchain `rust-toolchain.toml` already pins, and that CI and `wheels.yml` already build with. Base re-pinned by digest (`sha256:82150a52…`, resolved from the registry, not guessed).

The assertion is now **derived rather than written down**. It reads the channel from `rust-toolchain.toml` and the floor from `[workspace.package] rust-version`, then requires:

1. the toolchain clears the MSRV,
2. every `RUSTUP_TOOLCHAIN` equals that channel,
3. the base image tag carries the same toolchain — otherwise `RUSTUP_TOOLCHAIN` silently triggers a download at build time and the digest pin stops meaning anything.

No version literal is left to drift.

Worth noting this test's own history: `test_every_from_is_digest_pinned_and_runtime_is_distroless` already carries the comment *"Assert the CONTRACT, not one image name"* after pinning an exact base broke it once. The toolchain kept its constant and repeated the bug.

## Verified

| check | result |
|---|---|
| new test when the toolchain drifts | **fails**: `'1.89.0' != '1.98.0'` — *"Dockerfile.cpu builds with 1.89.0 but rust-toolchain.toml pins 1.98.0"* |
| restored | 10 passed |
| full scripts suite, as CI runs it | **473 passed** |

The remaining `1.89.0` strings in `test_qualify_crate_archives.py` and `test_release_evidence_status.py` are mock `side_effect` fixtures, not MSRV assertions — checked, left alone.

**Follow-up:** nothing builds these images on any lane, so a derived test is the only guard. An image build on tag would make it real — folds naturally into the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4