### PR TITLE
fix(release): the pipeline would have hung, then published nothing, and said green

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,13 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v6.0.0
         with:
-          pattern: wheel-*
+          # Named exactly, not `wheel-*`. wheels.yml also uploads
+          # wheel-functional-*, wheel-tutorial-* and wheel-cuda13-* -- evidence
+          # bundles that carry repo-root prefixes, so a glob lands DIRECTORIES in
+          # staged/. `gh release upload` rejects a directory, and the version
+          # assertion and checksums below only walk the top level, so the extra
+          # trees would ship unchecked or break the upload outright.
+          pattern: wheel-{linux-x86_64,macos-aarch64,windows-x64}
           path: staged
           merge-multiple: true
       - name: assert the tag and the artifacts agree
@@ -70,17 +76,42 @@ jobs:
           # wheel built from the wrong tree cannot be released under this tag.
           pep440="$(printf '%s' "$version" | tr -d '-' | sed 's/rc\./rc/')"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Derive the distribution name rather than writing it down. A literal here
+          # would silently stop matching the day the project is renamed, and the
+          # gate would pass by matching nothing.
+          dist="$(python3 -c "
+          import tomllib,pathlib
+          print(tomllib.loads(pathlib.Path('crates/tritium-py/pyproject.toml').read_text())['project']['name'].replace('-','_'))
+          ")"
+          echo "expecting ${dist}-${pep440}-* wheels"
+          # A stray directory means the artifact pattern over-matched; `gh release
+          # upload` rejects directories, and the checks below only walk the top level.
+          for d in staged/*/; do
+            [ -e "$d" ] || continue
+            echo "::error::staged/ contains a directory ($d) - the artifact pattern over-matched"
+            exit 1
+          done
           found=0
           for w in staged/*.whl; do
-            found=1
+            found=$((found + 1))
             base="$(basename "$w")"
             case "$base" in
-              tritium_torch-"$pep440"-*) ;;
-              *) echo "::error::$base does not carry version $pep440 (tag $tag)"; exit 1 ;;
+              "$dist"-"$pep440"-*) ;;
+              *) echo "::error::$base is not ${dist}-${pep440} (tag $tag)"; exit 1 ;;
             esac
           done
-          [ "$found" = 1 ] || { echo "::error::no wheels were produced"; exit 1; }
-          echo "all wheels carry $pep440"
+          # Every platform, or none. A partial set publishes a release that fails to
+          # install on the platforms whose wheel silently went missing -- which is
+          # exactly how tritium-torch 1.1.0rc1 shipped Linux-only.
+          missing=""
+          for plat in manylinux_2_28_x86_64 macosx_11_0_arm64 win_amd64; do
+            ls staged/*-"$plat".whl >/dev/null 2>&1 || missing="$missing $plat"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::missing platform wheels:$missing"; exit 1
+          fi
+          [ "$found" -eq 3 ] || { echo "::error::expected 3 wheels, found $found"; exit 1; }
+          echo "all $found wheels carry ${dist}-${pep440}, every platform present"
       - name: checksums
         shell: bash
         run: |
@@ -149,7 +180,18 @@ jobs:
           subject-path: staged/*.whl
       - name: notes from CHANGELOG
         shell: bash
-        run: python scripts/release-notes.py "${{ needs.collect.outputs.version }}" > NOTES.md
+        run: |
+          set -euo pipefail
+          # A workflow_dispatch re-run checks out the TAG, and tags cut before this
+          # pipeline existed have no release-notes.py -- v1.1.0-rc.1's tree is 320
+          # commits behind main. Fall back to GitHub's generated notes rather than
+          # failing a republish on a script the old tree never contained.
+          if [ -f scripts/release-notes.py ]; then
+            python scripts/release-notes.py "${{ needs.collect.outputs.version }}" > NOTES.md
+          else
+            echo "::notice::this tag predates scripts/release-notes.py; using generated notes"
+            : > NOTES.md
+          fi
       - name: create or update the release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -159,10 +201,13 @@ jobs:
           set -euo pipefail
           prerelease=""
           case "$TAG" in *-rc.*|*-alpha*|*-beta*) prerelease="--prerelease" ;; esac
+          # An empty NOTES.md means the fallback above fired; let GitHub generate them.
+          notes=(--notes-file NOTES.md)
+          [ -s NOTES.md ] || notes=(--generate-notes)
           if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --notes-file NOTES.md $prerelease
+            gh release edit "$TAG" "${notes[@]}" $prerelease
           else
-            gh release create "$TAG" --title "$TAG" --notes-file NOTES.md $prerelease --verify-tag
+            gh release create "$TAG" --title "$TAG" "${notes[@]}" $prerelease --verify-tag
           fi
           gh release upload "$TAG" staged/* --clobber
 
@@ -210,8 +255,12 @@ jobs:
             echo "::notice::publishing with the stored CARGO_REGISTRY_TOKEN secret"
             export CARGO_REGISTRY_TOKEN="$SECRET_TOKEN"
           else
-            echo "::notice::no crates.io credential - skipping. Register a trusted"
-            echo "publisher (preferred) or set the CARGO_REGISTRY_TOKEN secret."
-            exit 0
+            echo "::error::no crates.io credential. Register a trusted publisher"
+            echo "(preferred) or set the CARGO_REGISTRY_TOKEN secret. Failing rather"
+            echo "than reporting a green release that published nothing."
+            exit 1
           fi
-          scripts/publish-crates.sh
+          # --yes-publish is REQUIRED. Without it publish-crates.sh takes its
+          # dry-run branch, prints "PREFLIGHT OK" and exits 0 -- so the job went
+          # green having uploaded no crate at all, with or without a credential.
+          scripts/publish-crates.sh --yes-publish

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,15 @@ on:
   # calls it via workflow_call. Keeping both triggers would build the whole
   # matrix twice on every release, and publish from whichever finished first.
   workflow_call:
+    inputs:
+      build_cuda:
+        description: >-
+          Build and execute the CUDA 13 wheel. Requires a registered
+          [self-hosted, linux, x64, cuda, sm89] runner; without one the job
+          queues forever and every downstream release job waits on it.
+        required: false
+        type: boolean
+        default: false
   pull_request:
     # Build-only smoke: a release (or dispatch) builds the full matrix; on PRs we
     # keep the packaging path honest without running it on every commit to main.
@@ -438,9 +447,13 @@ jobs:
 
   cuda-wheel-smoke:
     name: Linux CUDA 13 wheel · Torch 2.11 · Python 3.13 · sm_89
-    if: >-
-      startsWith(github.ref, 'refs/tags/v') ||
-      (github.event_name == 'workflow_dispatch' && inputs.build_cuda)
+    # Opt-in only. This used to fire on any tag, which meant a release requested a
+    # self-hosted sm89 runner -- and no self-hosted runner is registered on this
+    # repository at all. A queued job is not a failed job: `build` would never
+    # complete, so collect/pypi/github-release/crates would never start and the
+    # release would hang rather than fail. `inputs.build_cuda` covers both the
+    # dispatch input and the workflow_call input above.
+    if: ${{ inputs.build_cuda }}
     runs-on: [self-hosted, linux, x64, cuda, sm89]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/crates/tritium-py/Cargo.toml
+++ b/crates/tritium-py/Cargo.toml
@@ -6,6 +6,12 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 readme = "README.md"
+# NOT a crates.io crate. It ships to PyPI as a wheel; the Rust crate is only the
+# extension module inside it. publish-crates.sh excluded it by omitting it from
+# ORDER -- an exclusion that lives in a different file and holds only as long as
+# nobody types `cargo publish -p tritium-py`. crates.io versions can be yanked but
+# never deleted, so one such command permanently squats the name.
+publish = false
 repository.workspace = true
 authors.workspace = true
 keywords.workspace = true

--- a/scripts/check-release-version.py
+++ b/scripts/check-release-version.py
@@ -12,7 +12,15 @@ from pathlib import Path
 from typing import Any
 
 
-RC_PATTERN = re.compile(r"1\.1\.0-rc\.(0|[1-9][0-9]*)")
+# A release version: X.Y.Z, optionally -rc.N. This used to be pinned literally to
+# `1.1.0-rc.N`, which meant the workspace could not hold any other version -- and
+# because this runs inside check-publish.sh, which is in the REQUIRED `publish-check`
+# CI job, tagging the 1.1.0 FINAL release would have turned ci-required red on the
+# release commit itself. A gate that forbids shipping is not a gate.
+RELEASE_PATTERN = re.compile(
+    r"(?P<base>0|[1-9][0-9]*(?:\.(?:0|[1-9][0-9]*)){2})"
+    r"(?:-rc\.(?P<rc>0|[1-9][0-9]*))?"
+)
 
 
 def require_equal(actual: Any, expected: str, label: str) -> None:
@@ -21,8 +29,10 @@ def require_equal(actual: Any, expected: str, label: str) -> None:
 
 
 def candidate_version(value: Any) -> str:
-    if not isinstance(value, str) or RC_PATTERN.fullmatch(value) is None:
-        raise ValueError(f"workspace version {value!r} is not a canonical 1.1.0-rc.N")
+    if not isinstance(value, str) or RELEASE_PATTERN.fullmatch(value) is None:
+        raise ValueError(
+            f"workspace version {value!r} is not a canonical X.Y.Z or X.Y.Z-rc.N"
+        )
     return value
 
 

--- a/scripts/tests/test_check_release_version.py
+++ b/scripts/tests/test_check_release_version.py
@@ -11,10 +11,36 @@ SPEC.loader.exec_module(MODULE)
 
 
 class ReleaseVersionTests(unittest.TestCase):
-    def test_candidate_requires_canonical_v11_rc(self):
-        self.assertEqual(MODULE.candidate_version("1.1.0-rc.0"), "1.1.0-rc.0")
-        self.assertEqual(MODULE.candidate_version("1.1.0-rc.12"), "1.1.0-rc.12")
-        for invalid in ("1.0.0", "1.1.0", "1.1.0-rc.01", "1.2.0-rc.0", None):
+    def test_candidate_accepts_any_canonical_release_or_rc(self):
+        """Format is the contract here, not one particular version.
+
+        This test used to require the workspace version to be literally
+        `1.1.0-rc.N`, rejecting `1.1.0` and `1.2.0-rc.0`. That is not what the
+        script is for -- it exists to catch a version MIRROR drifting from
+        Cargo.toml (pyproject, npm, Cargo.lock, the compatibility receipt), and it
+        uses the workspace version only as the reference to compare against.
+
+        The pin was actively harmful: this runs inside check-publish.sh, which is
+        the REQUIRED `publish-check` CI job, so tagging the 1.1.0 final release
+        would have failed ci-required on the release commit itself. A gate that
+        forbids shipping the next version is not protecting anything.
+        """
+        for valid in ("1.1.0-rc.0", "1.1.0-rc.12", "1.1.0", "1.2.0-rc.0", "2.0.0"):
+            with self.subTest(valid=valid):
+                self.assertEqual(MODULE.candidate_version(valid), valid)
+
+    def test_candidate_still_rejects_non_canonical_spellings(self):
+        """Loosening the version must not loosen the SPELLING it accepts."""
+        for invalid in (
+            "1.1.0-rc.01",  # leading zero
+            "1.1.0rc1",     # PEP 440 spelling; Cargo uses -rc.N
+            "1.1",          # not three components
+            "v1.1.0",       # tag spelling, not a version
+            "1.1.0-rc",     # rc without an ordinal
+            "1.1.0-alpha.1",
+            "",
+            None,
+        ):
             with self.subTest(invalid=invalid), self.assertRaises(ValueError):
                 MODULE.candidate_version(invalid)
 


### PR DESCRIPTION
Six defects in the release path merged by #36 — found in review by the parallel session, each reproduced here before fixing. **Two were individually sufficient to make rc.2 a non-event.**

## It would never have reached the publish jobs

`wheels.yml`'s `cuda-wheel-smoke` was gated `startsWith(github.ref, 'refs/tags/v')`, and a called workflow inherits the caller's ref — so a **tag** requested a `[self-hosted, linux, x64, cuda, sm89]` runner.

`gh api .../actions/runners` returns **empty**: this repo has no self-hosted runner registered at all. A queued job is not a failed job, so `build` would never complete and `collect`/`pypi`/`github-release`/`crates` would never start. **The release would hang, not fail.** Now opt-in via a `workflow_call` input that `release.yml` doesn't set.

## And if it had, it would have published no crates

`release.yml` invoked `scripts/publish-crates.sh` with no arguments. Line 61 takes its **dry-run branch** without `--yes-publish`, prints `PREFLIGHT OK`, exits 0. With a perfectly valid OIDC token or `CARGO_REGISTRY_TOKEN`, zero crates upload and the job reports success.

Fixed — and the missing-credential path now **fails** instead of exiting 0. A release that publishes nothing must not be green.

## The rest

- **`pattern: wheel-*`** also matched `wheel-functional-*`, `wheel-tutorial-*`, `wheel-cuda13-*`, which carry repo-root prefixes and land as **directories** in `staged/`. `gh release upload` rejects directories, and the version assertion and checksums only walk the top level. Named the three platform artifacts exactly.
- **`check-release-version.py` pinned `RC_PATTERN` to `1\.1\.0-rc\.N`.** It runs inside `check-publish.sh` — the **required** `publish-check` job — so tagging `v1.1.0` final would have failed `ci-required` *on the release commit itself*. The script exists to catch a version **mirror** drifting from Cargo.toml (pyproject, npm, `Cargo.lock`, compatibility receipt) and uses the version only as the comparison reference; nothing needed it to be 1.1.0. Generalized to `X.Y.Z` / `X.Y.Z-rc.N`, with the accepted **spelling** unchanged and now tested explicitly.
- **Notes fallback** — a `workflow_dispatch` re-run checks out the tag, and tags cut before this pipeline have no `release-notes.py` (rc.1's tree is 320 commits back). Falls back to generated notes.
- **`crates/tritium-py` now sets `publish = false`.** It ships to PyPI; the crate is only the extension module inside the wheel. It was excluded from crates.io by *omission from another file's array* — which held only until someone typed `cargo publish -p tritium-py`. Versions yank, never delete.

## Also hardened

The version gate now **derives** the distribution name from `pyproject.toml` instead of matching the literal `tritium_torch-` — which would have silently stopped matching, and passed by matching nothing, at the rename queued next. It also rejects a stray directory in `staged/`, and requires all three platform wheels: a partial set is exactly how `tritium-torch 1.1.0rc1` shipped Linux-only and broke `pip install` on macOS and Windows for weeks.

## Verified

| check | result |
|---|---|
| `cargo publish -p tritium-py --dry-run` | ``error: `tritium-py` cannot be published.`` |
| `cargo metadata` | `tritium-py publish = []` |
| `candidate_version`, 9 spellings | all as specified |
| actionlint + shellcheck 0.11.0 | clean, six workflows |
| scripts suite, as CI runs it | **479 passed** |

**Not fixed here:** CHANGELOG has no `[1.1.0-rc.N]` heading, so `release-notes.py` always takes its Unreleased fallback and ships the disclaimer. That belongs with the version bump.

Reported-by: parallel session (`draft-reconcile-performance-analysis`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4