### PR TITLE
docs(security): provenance is implemented now — say so, and say exactly where

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -107,8 +107,13 @@ material user risk, but the reason and remaining exposure will be documented.
 ## Supply-chain and deployment boundary
 
 Release artifacts are admitted by digest, source revision, and SBOM gates.
-Cryptographic build provenance and artifact signatures are **not yet
-implemented** — do not treat a downloaded artifact as attested. Model/tokenizer licenses and authenticity remain separate
+Python wheels attached to a GitHub Release carry **SLSA build provenance**
+attestations produced by `release.yml` (`actions/attest-build-provenance`) —
+verify one with `gh attestation verify <wheel> --repo Quitetall/tritium`.
+The same wheels on PyPI carry PEP 740 provenance, uploaded by the trusted-publishing step.
+crates.io crates and the OCI images are **not** attested: crates publish
+with a stored registry token, and the images are built outside CI. Do not
+treat those as attested. Model/tokenizer licenses and authenticity remain separate
 from numerical compatibility: a loadable artifact is not automatically trusted
 or redistributable. Operators must verify candidate/public manifests and should
 run serving images with the documented non-root, read-only, bounded-resource


### PR DESCRIPTION
`SECURITY.md:110` still says cryptographic build provenance is *"not yet implemented — do not treat a downloaded artifact as attested."* True on 2026-09-01; false since `v1.1.0-rc.2` shipped this morning through `release.yml`.

```
gh attestation verify pytritium-1.1.0rc2-cp39-abi3-manylinux_2_28_x86_64.whl --repo Quitetall/tritium
```

passes against the shipped wheel. Under-claiming a control is the safer direction to be wrong in — but it now tells users not to trust a verification they can run.

**Scoped to what is actually attested:**
- Wheels on the GitHub Release — **yes**, SLSA provenance via `actions/attest-build-provenance`.
- crates.io — **no**; published with the stored `CARGO_REGISTRY_TOKEN` until per-crate trusted publishing is set up.
- OCI images — **no**; built outside CI.

One-paragraph docs change, no code. Follows the rc.2 release (#40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166rZwZDrh6awfgZzLS3Ez4